### PR TITLE
Add GPG.search_keys

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -98,7 +98,8 @@ class GPGBase(object):
                        'list':     _parsers.ListKeys,
                        'sign':     _parsers.Sign,
                        'verify':   _parsers.Verify,
-                       'packets':  _parsers.ListPackets }
+                       'packets':  _parsers.ListPackets,
+                       'search':   _parsers.SearchKeys }
 
     def __init__(self, binary=None, home=None, keyring=None, secring=None,
                  use_agent=False, default_preference_list=None,
@@ -617,6 +618,51 @@ class GPGBase(object):
         proc = self._open_subprocess(args)
         self._collect_output(proc, result)
         log.debug('recv_keys result: %r', result.__dict__)
+        return result
+
+    def _search_keys(self, names, keyserver=None):
+        """Search for keys on a keyserver.
+
+        Warning: keyservers may return short key ids, long key ids, or
+        fingerprints. This is determined by the keyserver, and, while the spec
+        recommends always returning the longest possible key identifier, it
+        appears most keyservers return short key ids.
+
+        :param str names: Each ``names`` argument should be string specifying
+            a user id (valid ways of describing user IDs are listed in the gpg man
+            page in the section "HOW TO SPECIFY A USER ID"). Multiple names are
+            joined to create the search string for the keyserver.
+        :param str keyserver: The keyserver to search for ``names`` on;
+            defaults to :property:`gnupg.GPG.keyserver`.
+        """
+        if not keyserver:
+            keyserver = self.keyserver
+
+        # Use --batch to get the search results without entering the
+        # interactive step
+        args = ['--batch', '--with-colons',
+                '--keyserver {}'.format(keyserver),
+                '--search-keys {}'.format(names)]
+        log.info('Searching for keys from %s: %s' % (keyserver, names))
+
+        result = self._result_map['search'](self)
+        p = self._open_subprocess(args)
+        # gpg --search-keys produces no status-fd (AFAICT)
+        # Get the search results from stdout
+        self._collect_output(p, result)
+        lines = result.data.decode(self._encoding,
+                                   self._decode_errors).splitlines()
+        valid_keywords = 'pub uid'.split()
+        for line in lines:
+            log.debug("%r", line.rstrip())
+            L = line.strip().split(':')
+            if not L:
+                continue
+            keyword = L[0]
+            if keyword in valid_keywords:
+                getattr(result, keyword)(L)
+
+        log.debug('search_keys result: %r', result)
         return result
 
     def _sign_file(self, file, default_key=None, passphrase=None,

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 
 import collections
 import re
+import datetime
 
 from .      import _util
 from ._util import log
@@ -474,6 +475,7 @@ def _get_options_group(group=None):
                                    '--passphrase-fd',
                                    '--status-fd',
                                    '--verify-options',
+                                   '--search-keys',
                                ])
     #: These have their own parsers and don't really fit into a group
     other_options = frozenset(['--debug-level',
@@ -1364,3 +1366,58 @@ class ListPackets(object):
             pass
         else:
             raise ValueError("Unknown status message: %r" % key)
+
+class SearchKeys(list):
+    """Parse search results from --search-keys
+
+    :type gpg: :class:`gnupg.GPG`
+    :param gpg: An instance of :class:`gnupg.GPG`.
+    """
+
+    # http://tools.ietf.org/html/rfc2440#section-9.1
+    _PK_ALGO_CONSTANTS = {
+        1 : 'RSA (Encrypt or Sign)',
+        2 : 'RSA Encrypt-only',
+        3 : 'RSA Sign-only',
+        16 : 'Elgamal (Encrypt-only)',
+        17 : 'DSA (Digital Signature Standard)',
+        18 : 'Reserved for Elliptic Curve',
+        19 : 'Reserved for ECDSA',
+        20 : 'Elgamal (Encrypt or Sign)',
+        21 : 'Reserved for Diffie-Hellman (X9.42, as defined for IETF-S/MIME)',
+    }
+    _PK_ALGO_CONSTANTS.update(dict.fromkeys(range(100,110),
+                                           'Private/Experimental algorithm'))
+
+    def _convert_ks_date(self, date):
+        if date == '':
+            return None
+        return datetime.datetime.utcfromtimestamp(int(date))
+
+    def __init__(self, gpg):
+        super(SearchKeys, self).__init__()
+        self._gpg = gpg
+        self.curkey = None
+
+    def pub(self, args):
+        self.curkey = dict(
+            keyid=args[1],
+            algo=self._PK_ALGO_CONSTANTS[int(args[2])],
+            keylen=int(args[3]),
+            creationdate=self._convert_ks_date(args[4]),
+            expirationdate=self._convert_ks_date(args[5]),
+            flags=args[6] or None,
+            uids=[],
+        )
+        self.append(self.curkey)
+
+    def uid(self, args):
+        self.curkey['uids'].append(dict(
+            uid=ESCAPE_PATTERN.sub(lambda m: chr(int(m.group(1), 16)), args[1]),
+            creationdate=self._convert_ks_date(args[2]),
+            expirationdate=self._convert_ks_date(args[3]),
+            flags=args[4] or None,
+        ))
+
+    def _handle_status(self, key, value):
+        pass

--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -70,7 +70,7 @@ _conf = os.path.join(os.path.join(_user, '.config'), 'python-gnupg')
                                      ## $HOME/.config/python-gnupg
 
 ## Logger is disabled by default
-log = _logger.create_logger(0)
+log = _logger.create_logger(10)
 
 
 def find_encodings(enc=None, system=False):

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -381,6 +381,27 @@ class GPG(GPGBase):
         else:
             log.error("No keyids requested for --recv-keys!")
 
+    def search_keys(self, *names, **kwargs):
+        """Search for keys on a keyserver.
+
+        >>> gpg = gnupg.GPG(homedir="doctests")
+        >>> search_results = gpg.search_keys('3FF0DB166A7476EA')
+        >>> assert search_results[0]['uids'][0]['uid'] == 'Nicholas Thomas (Repository signing key) <root@lupine.me.uk>'
+
+        :param str names: Each ``names`` argument should be string specifying
+            a user id (valid ways of describing user IDs are listed in the gpg man
+            page in the section "HOW TO SPECIFY A USER ID"). Multiple names are
+            joined to create the search string for the keyserver.
+        :param str keyserver: The keyserver to search for ``names`` on;
+            defaults to :property:`gnupg.GPG.keyserver`.
+        """
+        if names:
+            # xxx since GPG joins all the names into one search string, we
+            # don't need to escape or quote names with spaces in them afaict
+            return self._search_keys(' '.join(names), **kwargs)
+        else:
+            log.error("No names given to search for in --search-keys!")
+
     def delete_keys(self, fingerprints, secret=False, subkeys=False):
         """Delete a key, or list of keys, from the current keyring.
 

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -530,6 +530,16 @@ class GPGTestCase(unittest.TestCase):
         self.assertTrue(os.path.isfile(keyfile))
         self.assertGreater(os.stat(keyfile).st_size, 0)
 
+    def test_search_keys_default(self):
+        """Testing searching keys on a keyserver."""
+        query = "garrettr@riseup.net"
+        search_results = self.gpg.search_keys(query)
+        self.assertIsNotNone(search_results)
+        self.assertEquals(len(search_results), 1)
+        self.assertEquals(search_results[0]['algo'], 'RSA (Encrypt or Sign)')
+        self.assertEquals(search_results[0]['keyid'], 'D3EF9CAE')
+        self.assertEquals(search_results[0]['keylen'], 4096)
+
     def test_import_and_export(self):
         """Test that key import and export works."""
         self.test_list_keys_initial_public()
@@ -1008,7 +1018,8 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                             'test_import_and_export',
                             'test_deletion',
                             'test_import_only',
-                            'test_recv_keys_default',]), }
+                            'test_recv_keys_default',]),
+           'searchkeys': set(['test_search_keys_default']), }
 
 def main(args):
     if not args.quiet:


### PR DESCRIPTION
Implementation of `GPG.search_keys`, which allows users to search keyservers a la `--search-keys`. The API is pretty much identical to `GPG.recv_keys`. I based the parser implementation on ListKeys.

search_keys returns a list of search results. Each result is a dictionary with metadata about the key, including the keyid and a list of uids. The keyid can then be passed to `GPG.recv_keys` to retrieve the actual key. Metadata values are converted into useful Python data types wherever possible.

There is also a basic unit test.

This commit closes #19.
