### PR TITLE
allow symlinks for the binary and resolve them

### DIFF
--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -282,7 +282,7 @@ def _find_binary(binary=None):
 
     try:
         assert os.path.isabs(found), "Path to gpg binary not absolute"
-        assert not os.path.islink(found), "Path to gpg binary is symlink"
+        found = os.path.realpath(found)
         assert os.access(found, os.X_OK), "Lacking +x perms for gpg binary"
     except (AssertionError, AttributeError) as ae:
         log.error(ae.message)


### PR DESCRIPTION
MacGPG2 installs a symlink in /usr/local/bin/gpg which is found first by _find_binary
