### PR TITLE
remove print statements in logger

### DIFF
--- a/gnupg/_logger.py
+++ b/gnupg/_logger.py
@@ -86,10 +86,8 @@ def create_logger(level=logging.NOTSET):
 
         formatr = logging.Formatter(_fmt)
         handler.setFormatter(formatr)
-        print("Starting the logger...")
     else:
         handler = NullHandler()
-        print("GnuPG logging disabled...")
 
     log = logging.getLogger('gnupg')
     log.addHandler(handler)


### PR DESCRIPTION
logger always prints information to stdout.
This is bad practice and conflicts with programs which write output to stdout.
