### PR TITLE
prune unused exceptions imports for Python 3

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -26,7 +26,6 @@ from __future__ import absolute_import
 import atexit
 import codecs
 import encodings
-import exceptions
 ## For AOS, the locale module will need to point to a wrapper around the
 ## java.util.Locale class.
 ## See https://code.patternsinthevoid.net/?p=android-locale-hack.git

--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -27,7 +27,6 @@ from time       import mktime
 
 import codecs
 import encodings
-import exceptions
 import os
 import psutil
 import threading

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -31,7 +31,6 @@ from __future__ import absolute_import
 from codecs     import open as open
 
 import encodings
-import exceptions
 import functools
 import os
 import re


### PR DESCRIPTION
Resolves #41.

Did not seem to cause any test failures (some were failing for other reasons, like too many open files), and I have not been able to find a case where these imports are used.
