### PR TITLE
failing test case for the monkeysign test key

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -1048,7 +1048,7 @@ class ImportResult(object):
         :rtype: bool
         :returns: True if we have immport some keys, False otherwise.
         """
-        if self.counts.not_imported > 0: return False
+        if self.counts['not_imported'] > 0: return False
         if len(self.fingerprints) == 0: return False
         return True
     __bool__ = __nonzero__

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -564,7 +564,7 @@ class GPGTestCase(unittest.TestCase):
     def test_import_only(self):
         """Test that key import works."""
         self.test_list_keys_initial_public()
-        self.gpg.import_keys(KEYS_TO_IMPORT)
+        self.assertTrue(self.gpg.import_keys(KEYS_TO_IMPORT))
         public_keys = self.gpg.list_keys()
         self.assertTrue(is_list_with_len(public_keys, 2),
                         "2-element list expected")


### PR DESCRIPTION
for some reason, i can import that key fine in the monkeysign library and gpg, but can't import it in python-gnupg
