### PR TITLE
Ignore PROGRESS messages during verify operation

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -1212,7 +1212,7 @@ class Verify(object):
             self.trust_level = self.TRUST_LEVELS[key]
         elif key in ("RSA_OR_IDEA", "NODATA", "IMPORT_RES", "PLAINTEXT",
                      "PLAINTEXT_LENGTH", "POLICY_URL", "DECRYPTION_INFO",
-                     "DECRYPTION_OKAY", "INV_SGNR"):
+                     "DECRYPTION_OKAY", "INV_SGNR", "PROGRESS"):
             pass
         elif key == "BADSIG":
             self.valid = False


### PR DESCRIPTION
Parsing such messages would change documented behavior (which specifies a
limited set of messages, not conforming with the given status codes). Ignoring
them is thus the safer change.
