### PR TITLE
Continue search for a usable binary if entries are symlinks

### DIFF
--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -277,7 +277,7 @@ def _find_binary(binary=None):
         elif os.access(binary, os.X_OK):
             found = binary
     if found is None:
-        try: found = _which('gpg')[0]
+        try: found = _which('gpg', abspath_only=True, disallow_symlinks=True)[0]
         except IndexError as ie:
             log.error("Could not find binary for 'gpg'.")
             try: found = _which('gpg2')[0]
@@ -286,14 +286,7 @@ def _find_binary(binary=None):
     if found is None:
         raise RuntimeError("GnuPG is not installed!")
 
-    try:
-        assert os.path.isabs(found), "Path to gpg binary not absolute"
-        assert not os.path.islink(found), "Path to gpg binary is symlink"
-        assert os.access(found, os.X_OK), "Lacking +x perms for gpg binary"
-    except (AssertionError, AttributeError) as ae:
-        log.error(str(ae))
-    else:
-        return found
+    return found
 
 def _has_readwrite(path):
     """
@@ -489,7 +482,7 @@ def _utc_epoch():
     """Get the seconds since epoch."""
     return int(mktime(localtime()))
 
-def _which(executable, flags=os.X_OK):
+def _which(executable, flags=os.X_OK, abspath_only=False, disallow_symlinks=False):
     """Borrowed from Twisted's :mod:twisted.python.proutils .
 
     Search PATH for executable files with the given name.
@@ -512,6 +505,17 @@ def _which(executable, flags=os.X_OK):
     :returns: A list of the full paths to files found, in the order in which
               they were found.
     """
+    def _can_allow(p):
+        if not os.access(p, flags):
+            return False
+        if abspath_only and not os.path.abspath(p):
+            log.warn('Ignoring %r (path is not absolute)', p)
+            return False
+        if disallow_symlinks and os.path.islink(p):
+            log.warn('Ignoring %r (path is a symlink)', p)
+            return False
+        return True
+
     result = []
     exts = filter(None, os.environ.get('PATHEXT', '').split(os.pathsep))
     path = os.environ.get('PATH', None)
@@ -519,11 +523,11 @@ def _which(executable, flags=os.X_OK):
         return []
     for p in os.environ.get('PATH', '').split(os.pathsep):
         p = os.path.join(p, executable)
-        if os.access(p, flags):
+        if _can_allow(p):
             result.append(p)
         for e in exts:
             pext = p + e
-            if os.access(pext, flags):
+            if _can_allow(pext):
                 result.append(pext)
     return result
 


### PR DESCRIPTION
Existing code gives up searching for a GnuPG executable (returning None --
contrary to the docstring indicating that a RuntimeError will be thrown in all
cases where no binary can be found) if the first item found is a symlink or is
not accessed via an absolute path.

This refactored version moves the filtering logic down into the _which helper
-- and thus continues to search past unacceptable results -- even if the first
item found is not acceptable.
