### PR TITLE
Not sufficient to drop bad options; good ones need to be passed through.

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -161,7 +161,7 @@ class GPGBase(object):
         sec = _parsers._fix_unsafe(secring) if secring else 'secring.gpg'
         self.keyring = os.path.join(self._homedir, pub)
         self.secring = os.path.join(self._homedir, sec)
-        self.options = _parsers._sanitise(options) if options else None
+        self.options = list(_parsers._sanitise_list(options)) if options else None
 
         #: The version string of our GnuPG binary
         self.binary_version = '0.0.0'
@@ -197,7 +197,7 @@ class GPGBase(object):
                 "'verbose' must be boolean, string, or 0 <= n <= 9"
             assert isinstance(use_agent, bool), "'use_agent' must be boolean"
             if self.options is not None:
-                assert isinstance(self.options, str), "options not string"
+                assert isinstance(self.options, list), "options not list"
         except (AssertionError, AttributeError) as ae:
             log.error("GPGBase.__init__(): %s" % str(ae))
             raise RuntimeError(str(ae))

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -367,7 +367,7 @@ def _sanitise(*args):
                         checked += (val + " ")
                         log.debug("_check_option(): No checks for %s" % val)
 
-        return checked
+        return checked.rstrip(' ')
 
     is_flag = lambda x: x.startswith('--')
 
@@ -557,6 +557,9 @@ def _get_options_group(group=None):
                               '--list-public-keys',
                               '--list-secret-keys',
                               '--list-sigs',
+                              '--lock-multiple',
+                              '--lock-never',
+                              '--lock-once',
                               '--no-default-keyring',
                               '--no-default-recipient',
                               '--no-emit-version',

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -288,8 +288,8 @@ class GPGTestCase(unittest.TestCase):
         self.assertTrue(os.path.isabs(self.gpg.binary))
 
     def test_make_args_drop_protected_options(self):
-        """Test that unsupported gpg options are dropped."""
-        self.gpg.options = ['--tyrannosaurus-rex', '--stegosaurus']
+        """Test that unsupported gpg options are dropped, and supported ones remain."""
+        self.gpg.options = ['--tyrannosaurus-rex', '--stegosaurus', '--lock-never']
         gpg_binary_path = _util._find_binary('gpg')
         cmd = self.gpg._make_args(None, False)
         expected = [gpg_binary_path,
@@ -297,7 +297,8 @@ class GPGTestCase(unittest.TestCase):
                     '--homedir "%s"' % self.homedir,
                     '--no-default-keyring --keyring %s' % self.keyring,
                     '--secret-keyring %s' % self.secring,
-                    '--no-use-agent']
+                    '--no-use-agent',
+                    '--lock-never']
         self.assertListEqual(cmd, expected)
 
     def test_make_args(self):


### PR DESCRIPTION
Test not only that bad options get dropped, but that valid ones are passed through -- and fix bugs necessary for that extended test to pass.

Also adds missing `--lock-never`, `--lock-once` and `--lock-multiple` arguments to the whitelist.