### PR TITLE
versioneer: Allow dirty tag to be disabled

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -225,7 +225,8 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
     GIT = "git"
     if sys.platform == "win32":
         GIT = "git.cmd"
-    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always"],
+    stdout = run_command([GIT, "describe", "--tags", "--always"]
+                         + [] if 'IGNORE_DIRTY' in os.environ else ['--dirty'],
                          cwd=root)
     if stdout is None:
         return {}
@@ -409,7 +410,8 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
     GIT = "git"
     if sys.platform == "win32":
         GIT = "git.cmd"
-    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always"],
+    stdout = run_command([GIT, "describe", "--tags", "--always"]
+                         + [] if 'IGNORE_DIRTY' in os.environ else ['--dirty'],
                          cwd=root)
     if stdout is None:
         return {}


### PR DESCRIPTION
At present, packagers cannot apply local patches to python-gnupg via their package management system's patch mechanism (whatever that may be) without adding a `-dirty` tag to the version number. This can be unfortunate: Tools with a dependency on a specific version of `python-gnupg` can consider that dependency not to be satisfied due to the tag's impact on version numbering.

Allow this generally-useful behavior to be disabled by exporting `IGNORE_DIRTY` in the environment at build time.