### PR TITLE
MacOS was incorrectly being detected as Windows

### DIFF
--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -96,9 +96,7 @@ try:
 except NameError:
     _py3k = True
 
-_running_windows = False
-if "win" in sys.platform:
-    _running_windows = True
+_running_windows = sys.platform.startswith("win")
 
 ## Directory shortcuts:
 ## we don't want to use this one because it writes to the install dir:


### PR DESCRIPTION
The running_windows variable was causing MacOS to be detected as windows (because MacOS identifier is "darwin"). That breaks the rest of the code because MacOS handles the processes the same way as linux, instead of like windows does.

Changed

``` python
"win" in sys.platform
```

to

``` python
sys.platform.startswith("win")
```

So it only matches windows
