### PR TITLE
correct "printprint" to "fingerprint" (docfix)

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -904,7 +904,7 @@ class GPGBase(object):
         ...                                  passphrase='foo')
         >>> key = gpg.gen_key(key_settings)
         >>> message = "The crow flies at midnight."
-        >>> encrypted = str(gpg.encrypt(message, key.printprint))
+        >>> encrypted = str(gpg.encrypt(message, key.fingerprint))
         >>> assert encrypted != message
         >>> assert not encrypted.isspace()
         >>> decrypted = str(gpg.decrypt(encrypted))

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -935,7 +935,7 @@ generate keys. Please see
         ...     passphrase='foo')
         >>> key = gpg.gen_key(key_settings)
         >>> message = "The crow flies at midnight."
-        >>> encrypted = str(gpg.encrypt(message, key.printprint))
+        >>> encrypted = str(gpg.encrypt(message, key.fingerprint))
         >>> assert encrypted != message
         >>> assert not encrypted.isspace()
         >>> decrypted = str(gpg.decrypt(encrypted))


### PR DESCRIPTION
This was fixed in #40, but that was closed without merging.
