### PR TITLE
Pass GPG env variables to execve when executing gpg commands

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -593,9 +593,15 @@ class GPGBase(object):
         else:
             expand_shell = False
 
+        env = {"LANGUAGE": "en"}
+        for var in ["GPG_AGENT_INFO", "GPG_TTY", "GPG_PINENTRY_PATH"]:
+            val = os.getenv(var)
+            if val is not None:
+                env[var] = val
+
         return subprocess.Popen(cmd, shell=expand_shell, stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                env={'LANGUAGE': 'en'})
+                                env=env)
 
     def _read_response(self, stream, result):
         """Reads all the stderr output from GPG, taking notice only of lines


### PR DESCRIPTION
GnuPG uses a few environment variables to pass certain parameters about
where to find an agent. Among these, GPG_AGENT_INFO is most important,
since without that environment variable, gpg will only look in the
standard location for the gpg-agent socket.
