### PR TITLE
adds "NEWSIG" to ignored status messages.

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -1278,7 +1278,7 @@ class Verify(object):
         elif key in ("RSA_OR_IDEA", "NODATA", "IMPORT_RES", "PLAINTEXT",
                      "PLAINTEXT_LENGTH", "POLICY_URL", "DECRYPTION_INFO",
                      "DECRYPTION_OKAY", "INV_SGNR", "PROGRESS",
-                     "PINENTRY_LAUNCHED"):
+                     "PINENTRY_LAUNCHED", "NEWSIG"):
             pass
         elif key == "BADSIG":
             self.valid = False


### PR DESCRIPTION
I'm not exactly sure what is going on here, but we were getting an error that "NEWSIG" was not recognized during signature verification.

I did some googling and came across this. https://bitbucket.org/vinay.sajip/python-gnupg/issues/35/status-newsig-missing-in-verify

I believe that this update implements the same fix. It has worked for us (meaning that it stopped throwing the exception). I hope that it is not skipping the signature verification as well (I don't think that it is but I'm not familiar enough with the project to say). If this is correct, it would probably be helpful for others using this library.
