### PR TITLE
gpg will use sane defaults, the prior code prevents the setting of us…

### DIFF
--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -799,10 +799,8 @@ class GPG(GPGBase):
 
         for key, val in list(kwargs.items()):
             key = key.replace('_','-').title()
-            ## to set 'cert', 'Key-Usage' must be blank string
-            if not key in ('Key-Usage', 'Subkey-Usage'):
-                if type('')(val).strip():
-                    parms[key] = val
+            if type('')(val).strip():
+                parms[key] = val
 
         ## if Key-Type is 'default', make Subkey-Type also be 'default'
         if parms['Key-Type'] == 'default':


### PR DESCRIPTION
…age parameters

Correct me if I'm wrong, but it appears as if the prior code prevented setting usage parameters for keys and subkeys. Without that code, the generated keys still have cert, contrary to the comment.  This should fix #125. 