### PR TITLE
Allow automatic trustdb checks to be disabled.

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -561,6 +561,7 @@ def _get_options_group(group=None):
                               '--lock-multiple',
                               '--lock-never',
                               '--lock-once',
+                              '--no-auto-check-trustdb',
                               '--no-default-keyring',
                               '--no-default-recipient',
                               '--no-emit-version',

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -159,7 +159,8 @@ class GPG(GPGBase):
 
         # Make sure that the trustdb exists, or else GnuPG will exit with a
         # fatal error (at least it does with GnuPG>=2.0.0):
-        self.create_trustdb()
+        if not (self.options is not None and '--no-auto-check-trustdb' in self.options):
+            self.create_trustdb()
 
         # The --no-use-agent and --use-agent options were deprecated in GnuPG
         # 2.x, so we should set use_agent to None here to avoid having


### PR DESCRIPTION
Skip auto trustdb creation if option to not automatically update it at runtime is given.