### PR TITLE
Pass through important environment variables when executing gpg

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -593,9 +593,16 @@ class GPGBase(object):
         else:
             expand_shell = False
 
+        environment = {
+            'LANGUAGE': os.environ.get('LANGUAGE') or 'en',
+            'GPG_TTY': os.environ.get('GPG_TTY') or '',
+            'DISPLAY': os.environ.get('DISPLAY') or '',
+            'GPG_AGENT_INFO': os.environ.get('GPG_AGENT_INFO') or '',
+        }
+
         return subprocess.Popen(cmd, shell=expand_shell, stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                env={'LANGUAGE': 'en'})
+                                env=environment)
 
     def _read_response(self, stream, result):
         """Reads all the stderr output from GPG, taking notice only of lines


### PR DESCRIPTION
If gpg uses gpg-agent and calls a pinentry program without setting
GPG_TTY or DISPLAY, it won't work if it has to prompt the user for
a passphrase (rather than read it from some keyring process).

If you do the above without also exporting GPG_AGENT_INFO, you'll keep
being prompted for the passphrase each time; with it set, the running
agent will remember and not ask you again.

Passing through LANGUAGE makes the prompts show up in the right
language.
