### PR TITLE
[bug] Generated OpenPGP keys use sha1 for cert-digest-algo

### DIFF
--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -557,7 +557,7 @@ class GPG(GPGBase):
         :returns: The result mapping with details of the new key, which is a
                   :class:`GenKey <gnupg._parsers.GenKey>` object.
         """
-        args = ["--gen-key --batch"]
+        args = ["--gen-key --cert-digest-algo SHA512 --batch"]
         key = self._result_map['generate'](self)
         f = _make_binary_stream(input, self._encoding)
         self._handle_io(args, f, key, binary=True)


### PR DESCRIPTION
Use SHA512 for self sign a key.
- Resolves: https://leap.se/code/issues/7407
