### PR TITLE
Changed GPG homedir argument to $HOME/.gnupg

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -174,7 +174,7 @@ class GPGBase(object):
         """
         self.ignore_homedir_permissions = ignore_homedir_permissions
         self.binary  = _util._find_binary(binary)
-        self.homedir = os.path.expanduser(home) if home else _util._conf
+        self.homedir = os.path.expanduser(home) if home else _util._ugpg
         pub = _parsers._fix_unsafe(keyring) if keyring else 'pubring.gpg'
         sec = _parsers._fix_unsafe(secring) if secring else 'secring.gpg'
         self.keyring = os.path.join(self._homedir, pub)


### PR DESCRIPTION
Instead of `_util._conf` use `_util._ugpg` as default for homedir.

The documentation for the `homedir` parameter says:

> Full pathname to directory containing the public and private keyrings. Default is whatever GnuPG defaults to.

Therefore the default for it should be `_ugpg` (which is usually `$HOME/.gpg`) and not `_conf`
