### PR TITLE
[feat] parse revoked key

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -965,7 +965,6 @@ class ListKeys(list):
     |  crs = X.509 certificate and private key available
     |  ssb = secret subkey (secondary key)
     |  uat = user attribute (same as user id except for field 10).
-    |  rev = revocation signature
     |  pkd = public key data (special field format, see below)
     |  grp = reserved for gpgsm
     |  rvk = revocation key
@@ -979,6 +978,7 @@ class ListKeys(list):
         self.fingerprints = []
         self.uids = []
         self.sigs = {}
+        self.revs = {}
 
     def key(self, args):
         vars = ("""
@@ -989,10 +989,12 @@ class ListKeys(list):
             self.curkey[vars[i]] = args[i]
         self.curkey['uids'] = []
         self.curkey['sigs'] = {}
+        self.curkey['rev'] = {}
         if self.curkey['uid']:
             self.curuid = self.curkey['uid']
             self.curkey['uids'].append(self.curuid)
             self.sigs[self.curuid] = set()
+            self.revs[self.curuid] = set()
             self.curkey['sigs'][self.curuid] = []
         del self.curkey['uid']
         self.curkey['subkeys'] = []
@@ -1026,6 +1028,12 @@ class ListKeys(list):
     def sub(self, args):
         subkey = [args[4], args[11]]
         self.curkey['subkeys'].append(subkey)
+
+    def rev(self, args):
+        self.curkey['rev'] = {'keyid': args[4],
+                              'revtime': args[5],
+                              'uid': self.curuid
+                              }
 
     def _handle_status(self, key, value):
         pass

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -528,7 +528,7 @@ class GPG(GPGBase):
     def _parse_keys(self, result):
         lines = result.data.decode(self._encoding,
                                    self._decode_errors).splitlines()
-        valid_keywords = 'pub uid sec fpr sub sig'.split()
+        valid_keywords = 'pub uid sec fpr sub sig rev'.split()
         for line in lines:
             if self.verbose:
                 print(line)

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -512,6 +512,29 @@ class GPGTestCase(unittest.TestCase):
         self.assertTrue(is_list_with_len(private_keys, 1),
                         "1-element list expected")
 
+    def test_list_revoked_key(self):
+        """Test that a revoke key is set."""
+        self.assertEqual(len(self.gpg.list_keys()), 0)
+        with open(os.path.join(_files, 'revoked_key.pub')) as revoked_key:
+            self.gpg.import_keys(revoked_key.read())
+        result = self.gpg.list_sigs("1763FE94FC05F492285C2B7BA658D626E2A17629")
+        self.assertEqual(len(self.gpg.list_keys()), 1)
+        self.assertEqual(result[0]['rev']['keyid'], 'A658D626E2A17629')
+
+    def test_revoke_and_not_revoked_key(self):
+        """Test that a revoke key is set, but a nun revoked key still valid"""
+        with open(os.path.join(_files, 'revoked_key.pub')) as revoked_key:
+            self.gpg.import_keys(revoked_key.read())
+
+        self.gpg.list_sigs("1763FE94FC05F492285C2B7BA658D626E2A17629")
+
+        with open(os.path.join(_files, 'test_key_1.sec')) as fh1:
+            res = self.gpg.import_keys(fh1.read())
+
+        result = self.gpg.list_sigs(res.fingerprints[0])
+        self.assertEqual(len(self.gpg.list_keys()), 2)
+        self.assertEqual(result[1]['rev'], {})
+
     def test_public_keyring(self):
         """Test that the public keyring is found in the gpg home directory."""
         ## we have to use the keyring for GnuPG to create it:
@@ -1433,6 +1456,8 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                             'test_deletion_subkeys',
                             'test_import_only']),
            'recvkeys': set(['test_recv_keys_default']),
+           'revokekey': set(['test_list_revoked_key',
+                             'test_revoke_and_not_revoked_key']),
 }
 
 def main(args):


### PR DESCRIPTION
I am not sure if there is a reason, why revoked key wasn't parsed so far..might there be a security reason i do not understand?
- allow to parse revoked keys
- add tests
- realted: https://leap.se/code/issues/6089
