### PR TITLE
Ignoring all 'KEY_CONSIDERED' status lines

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -851,7 +851,7 @@ class GenKey(object):
 
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
-        if key in ("GOOD_PASSPHRASE"):
+        if key in ("GOOD_PASSPHRASE", "KEY_CONSIDERED"):
             pass
         elif key == "KEY_NOT_CREATED":
             self.status = 'key not created'
@@ -888,7 +888,9 @@ class DeleteResult(object):
 
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
-        if key == "DELETE_PROBLEM":
+        if key == "KEY_CONSIDERED":
+            pass
+        elif key == "DELETE_PROBLEM":
             self.status = self.problem_reason.get(value, "Unknown error: %r"
                                                   % value)
         else:
@@ -934,7 +936,9 @@ class Sign(object):
 
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
-        if key in ("USERID_HINT", "NEED_PASSPHRASE", "BAD_PASSPHRASE",
+        if key == "KEY_CONSIDERED":
+            pass
+        elif key in ("USERID_HINT", "NEED_PASSPHRASE", "BAD_PASSPHRASE",
                    "GOOD_PASSPHRASE", "MISSING_PASSPHRASE", "PINENTRY_LAUNCHED",
                    "BEGIN_SIGNING", "CARDCTRL", "INV_SGNR", "SIGEXPIRED"):
             self.status = key.replace("_", " ").lower()
@@ -1095,8 +1099,9 @@ class ImportResult(object):
 
         :raises ValueError: if the status message is unknown.
         """
-        if key == "IMPORTED":
-            # this duplicates info we already see in import_ok & import_problem
+        if key in ("IMPORTED", "KEY_CONSIDERED"):
+            # IMPORTED : duplicates info we already see in import_ok & import_problem
+            # KEY_CONSIDERED : not useful info
             pass
         elif key == "NODATA":
             self.results.append({'fingerprint': None,
@@ -1278,7 +1283,7 @@ class Verify(object):
         elif key in ("RSA_OR_IDEA", "NODATA", "IMPORT_RES", "PLAINTEXT",
                      "PLAINTEXT_LENGTH", "POLICY_URL", "DECRYPTION_INFO",
                      "DECRYPTION_OKAY", "INV_SGNR", "PROGRESS",
-                     "PINENTRY_LAUNCHED"):
+                     "PINENTRY_LAUNCHED", "KEY_CONSIDERED"):
             pass
         elif key == "BADSIG":
             self.valid = False
@@ -1460,7 +1465,7 @@ class Crypt(Verify):
         """
         if key in ("ENC_TO", "USERID_HINT", "GOODMDC", "END_DECRYPTION",
                    "BEGIN_SIGNING", "NO_SECKEY", "ERROR", "NODATA",
-                   "CARDCTRL"):
+                   "CARDCTRL", "KEY_CONSIDERED"):
             # in the case of ERROR, this is because a more specific error
             # message will have come first
             pass
@@ -1532,7 +1537,7 @@ class ListPackets(object):
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
         if key in ('NO_SECKEY', 'BEGIN_DECRYPTION', 'DECRYPTION_FAILED',
-                   'END_DECRYPTION', 'GOOD_PASSPHRASE', 'BAD_PASSPHRASE'):
+                   'END_DECRYPTION', 'GOOD_PASSPHRASE', 'BAD_PASSPHRASE', 'KEY_CONSIDERED'):
             pass
         elif key == 'NODATA':
             self.status = nodata(value)


### PR DESCRIPTION
As far as I understand the KEY_CONSIDERED status line, it is just a info message, and if somthing wrong happens, gpg will emit a more relevant status line which will be handled.
So I just added this status line case to be passed in all _handle_status methods.
