### PR TITLE
Add keyserver-options parser and expose ca-cert-file for recv-keys

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -29,6 +29,12 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse
+
+import os
 import re
 
 from .      import _util
@@ -73,6 +79,67 @@ def _check_keyserver(location):
                 keyserver = proto + host
                 return keyserver
             return None
+
+
+def _check_keyserver_option(ks_option):
+    """Check that the provided keyserver option is valid and safe.
+
+    :param str ks_option: A valid argument to --keyserver-option.
+    :rtype: :obj:`str` or :obj:`None`
+    :returns: A string of the keyserver option or None.
+    """
+    def _is_valid_file(option_value):
+        """Verify option value is a file."""
+        return os.path.isfile(option_value)
+
+    def _is_valid_integer(option_value):
+        """Verify option value is an integer."""
+        return str.isdigit(option_value)
+
+    def _is_valid_http_proxy(option_value):
+        """Verify option value looks like a proxy URL."""
+        if not (option_value.startswith('http://') or
+                option_value.startswith('https://')):
+            proxy = 'http://{0}'.format(option_value)
+        else:
+            proxy = option_value
+        parsed_url = urlparse.urlparse(proxy)
+        if parsed_url.scheme and parsed_url.hostname:
+            return True
+        else:
+            return False
+
+    boolean_options = {
+        'auto-key-retrieve',
+        'check-cert',
+        'honor-keyserver-url',
+        'honor-pka-record',
+        'keep-temp-files',
+        'include-disabled',
+        'include-revoked',
+        'include-subkeys',
+        'use-temp-files',
+    }
+    no_prefixed_options = set(['no{}'.format(opt) for opt in boolean_options])
+    options_with_validators = {
+        'ca-cert-file': _is_valid_file,
+        'http-proxy': _is_valid_http_proxy,
+        'max-cert-size': is_valid_integer,
+        'timeout': _is_valid_integer,
+    }
+    valid_simple_options = (set(['debug', 'verbose']) |
+                            boolean_options |
+                            no_prefixed_options)
+    if ks_option in valid_simple_options:
+        return ks_option
+    opt, opt_arg = ks_option.split('=', 1)
+    if opt in options_with_validators:
+        arg_ok = options_with_validators[opt](opt_arg)
+        if arg_ok:
+            return ks_option
+    log.debug('Dropping invalid keyserver option: {}'.format(ks_option))
+    return None
+
 
 def _check_preferences(prefs, pref_type=None):
     """Check cipher, digest, and compression preference settings.
@@ -330,7 +397,13 @@ def _sanitise(*args):
                         continue
                     elif flag in ['--keyserver-options']:
                         print('found keyserver options: %s' % v)
-                        checked += (v + " ")
+                        keyserver_option = _check_keyserver_option(v)
+                        if keyserver_option:
+                            log.debug('Setting keyserver option: %s' %
+                                keyserver_option)
+                            checked += (keyserver_option + " ")
+                        else:
+                            log.debug('Dropping keyserver option: %s' % v)
                         continue
 
                     ## the rest are strings, filenames, etc, and should be

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -328,6 +328,10 @@ def _sanitise(*args):
                             checked += (v + " ")
                         else: log.debug("Dropping keyserver: %s" % v)
                         continue
+                    elif flag in ['--keyserver-options']:
+                        print('found keyserver options: %s' % v)
+                        checked += (v + " ")
+                        continue
 
                     ## the rest are strings, filenames, etc, and should be
                     ## shell escaped:
@@ -496,6 +500,7 @@ def _get_options_group(group=None):
     #: These have their own parsers and don't really fit into a group
     other_options = frozenset(['--debug-level',
                                '--keyserver',
+                               '--keyserver-options',
 
                            ])
     #: These should have a directory for an argument

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -369,13 +369,22 @@ class GPG(GPGBase):
         """Import keys from a keyserver.
 
         >>> gpg = gnupg.GPG(homedir="doctests")
-        >>> key = gpg.recv_keys('hkp://pgp.mit.edu', '3FF0DB166A7476EA')
+        >>> key = gpg.recv_keys('3FF0DB166A7476EA',
+                                keyserver='hkp://pgp.mit.edu')
         >>> assert key
+
+        >>> ssl_keyserver = 'hkps://hkps.pool.sks-keyservers.net'
+        >>> ca_cert = '/home/user/hkps.pool.sks-keyservers.netCA.pem'
+        >>> gpg.recv_keys('6F682D87',
+                          keyserver=ssl_keyserver,
+                          keyserver_certs=ca_cert)
 
         :param str keyids: Each ``keyids`` argument should be a string
              containing a keyid to request.
         :param str keyserver: The keyserver to request the ``keyids`` from;
              defaults to `gnupg.GPG.keyserver`.
+        :param str keyserver_certs: A file passed as the CA cert file for the
+                                    keyserver.
         """
         if keyids:
             keys = ' '.join([key for key in keyids])


### PR DESCRIPTION
Hi!  I noticed I couldn't get hkps working without --keyserver-options so I tacked it through.  Please take a look and let me know what I can do to better make the code fit with the rest of the codebase and be committed upstream.

Thank you for such a lovely library, cheers!

ps: I've thought it would be good to warn about trying to use gpg v1 with '--keyserver-options' (which doesn't seem to work) or using 'ca-cert-file', and others deprecated and relegated to dirmngr in gpg v2.1.  Suggestions on how to handle each would be much appreciated.