### PR TITLE
Feature: extend key expiration date

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -145,6 +145,7 @@ class GPGBase(object):
                        'list':     _parsers.ListKeys,
                        'sign':     _parsers.Sign,
                        'verify':   _parsers.Verify,
+                       'extension': _parsers.KeyExtensionResult,
                        'packets':  _parsers.ListPackets }
 
     def __init__(self, binary=None, home=None, keyring=None, secring=None,

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -847,12 +847,13 @@ class KeyExtensionResult(object):
 
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
-        if key in ("USERID_HINT", "NEED_PASSPHRASE",
-                   "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
+        if key in ("USERID_HINT", "NEED_PASSPHRASE", "KEYEXPIRED",
+                   "SIGEXPIRED", "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
             pass
         elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE"):
             self.status = key.replace("_", " ").lower()
         else:
+            self.status = 'failed'
             raise ValueError("Unknown status message: %r" % key)
 
 

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -485,6 +485,7 @@ def _get_options_group(group=None):
                              '--recipient',
                              '--recv-keys',
                              '--send-keys',
+                             '--edit-key'
                              ])
     #: These options expect value which are left unchecked, though still run
     #: through :func:`_fix_unsafe`.
@@ -492,6 +493,8 @@ def _get_options_group(group=None):
                                    '--passphrase-fd',
                                    '--status-fd',
                                    '--verify-options',
+                                   '--command-fd',
+                                   '--passphrase',
                                ])
     #: These have their own parsers and don't really fit into a group
     other_options = frozenset(['--debug-level',
@@ -806,6 +809,51 @@ def progress(status_code):
     for key, value in lookup.items():
         if str(status_code) == key:
             return value
+
+
+class KeyExtensionInterface(object):
+    """ Interface that guards against misuse of --edit-key combined with --command-fd"""
+
+    def __init__(self, validity):
+        self._validity_option = validity
+        self._clean_key_extension_option()
+
+    def _clean_key_extension_option(self):
+        """validates the extension option supplied"""
+        allowed_entry = re.findall('^(\d+)(|w|m|y)$', self._validity_option)
+        if not allowed_entry:
+            raise UsageError("Key extension option: %s is not valid" % self._validity_option)
+
+    def gpg_interactive_input(self, extend_subkey=True):
+        """ processes series of inputs normally supplied on --edit-key but passed through stdin
+            this ensures that no other --edit-key command is actually passing through.
+        """
+        _input = "expire\n%s\n" % self._validity_option
+        if extend_subkey:
+            _input = "%skey 1\nexpire\n%s\n" % (_input, self._validity_option)
+        return "%ssave\n" % _input
+
+
+class KeyExtensionResult(object):
+    """Handle status messages for key expiry extension
+        It does not really have a job, but just to conform to the API
+    """
+    def __init__(self, gpg):
+        self._gpg = gpg
+        self.status = 'ok'
+
+    def _handle_status(self, key, value):
+        """Parse a status code from the attached GnuPG process.
+
+        :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
+        """
+        if key in ("USERID_HINT", "NEED_PASSPHRASE",
+                   "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
+            pass
+        elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE"):
+            self.status = key.replace("_", " ").lower()
+        else:
+            raise ValueError("Unknown status message: %r" % key)
 
 
 class GenKey(object):

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -563,14 +563,12 @@ class GPG(GPGBase):
                     the new expiration date can be obtained by .list_keys()
         """
 
-        args = ["--batch"]
-        if passphrase:
-            args.append("--passphrase %s" % passphrase)
-        args.extend(["--command-fd 0", "--edit-key %s" % keyid])
+        args = ["--command-fd 0", "--edit-key %s" % keyid]
 
         p = self._open_subprocess(args)
         result = self._result_map['extension'](self)
-        extension_input = KeyExtensionInterface(validity).gpg_interactive_input(extend_subkey)
+        passphrase = passphrase.encode(self._encoding) if passphrase else passphrase
+        extension_input = KeyExtensionInterface(validity, passphrase).gpg_interactive_input(extend_subkey)
         p.stdin.write(extension_input)
         self._collect_output(p, result, stdin=p.stdin)
         return result

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -1381,6 +1381,23 @@ know, maybe you shouldn't be doing it in the first place.
             self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
             self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
 
+    def test_passphrase_with_space_on_key_extension(self):
+        """Test that wrong passphrase does not allow extension."""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        password_with_space = "passphrase with space"
+        key = self.generate_key("Haha", "ho.ho", passphrase=password_with_space,
+                                expire_date=tomorrow.strftime(date_format))
+
+        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase=password_with_space)
+        next_week = today + datetime.timedelta(weeks=1)
+
+        current_keys = self.gpg.list_keys()
+        for fecthed_key in current_keys:
+            self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
+            self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
+
     def test_wrong_passphrase_on_key_extension(self):
         """Test that wrong passphrase does not allow extension."""
         today = datetime.date.today()
@@ -1476,6 +1493,7 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                             'test_import_only']),
            'recvkeys': set(['test_recv_keys_default']),
            'extend': set(['test_key_extension',
+                          'test_passphrase_with_space_on_key_extension',
                           'test_wrong_passphrase_on_key_extension',
                           'test_invalid_extension_period_throws_exception_on_key_extension']),
 }

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import with_statement
 
+import datetime
 from argparse   import ArgumentParser
 from codecs     import open as open
 from functools  import wraps
@@ -357,6 +358,7 @@ class GPGTestCase(unittest.TestCase):
         os.remove(outfile)
 
     def generate_key_input(self, real_name, email_domain, key_length=None,
+                           expire_date=1,
                            key_type=None, subkey_type=None, passphrase=None):
         """Generate a GnuPG batch file for key unattended key creation."""
         name = real_name.lower().replace(' ', '')
@@ -366,7 +368,7 @@ class GPGTestCase(unittest.TestCase):
 
         batch = {'Key-Type': key_type,
                  'Key-Length': key_length,
-                 'Expire-Date': 1,
+                 'Expire-Date': expire_date,
                  'Name-Real': '%s' % real_name,
                  'Name-Email': ("%s@%s" % (name, email_domain))}
 
@@ -1364,6 +1366,46 @@ know, maybe you shouldn't be doing it in the first place.
             encrypted_message = fh.read()
             self.assertTrue(b"-----BEGIN PGP MESSAGE-----" in encrypted_message)
 
+    def test_key_extension(self):
+        """Test that extending key expiry date succeeds."""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
+
+        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase="haha.hehe")
+        next_week = today + datetime.timedelta(weeks=1)
+
+        current_keys = self.gpg.list_keys()
+        for fecthed_key in current_keys:
+            self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
+            self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
+
+    def test_wrong_passphrase_on_key_extension(self):
+        """Test that wrong passphrase does not allow extension."""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
+
+        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase="wrong passphrase")
+
+        current_keys = self.gpg.list_keys()
+        for fecthed_key in current_keys:
+            self.assertEqual(tomorrow, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
+            self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
+
+    def test_invalid_extension_period_throws_exception_on_key_extension(self):
+        """Test that key extension has to be positive value"""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
+
+        invalid_extension_option = "-1w"
+        with self.assertRaises(_parsers.UsageError):
+            self.gpg.extend_key(key.fingerprint, validity=invalid_extension_option, passphrase="haha.hehe")
+
 
 suites = { 'parsers': set(['test_parsers_fix_unsafe',
                            'test_parsers_fix_unsafe_semicolon',
@@ -1433,6 +1475,9 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                             'test_deletion_subkeys',
                             'test_import_only']),
            'recvkeys': set(['test_recv_keys_default']),
+           'extend': set(['test_key_extension',
+                          'test_wrong_passphrase_on_key_extension',
+                          'test_invalid_extension_period_throws_exception_on_key_extension']),
 }
 
 def main(args):

--- a/gnupg/test/test_parsers.py
+++ b/gnupg/test/test_parsers.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of python-gnupg, a Python interface to GnuPG.
+# Copyright © 2013 Isis Lovecruft, <isis@leap.se> 0xA3ADB67A2CDB8B35
+#           © 2013 Andrej B.
+#           © 2013 LEAP Encryption Access Project
+#           © 2008-2012 Vinay Sajip
+#           © 2005 Steve Traugott
+#           © 2004 A.M. Kuchling
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+"""test_util.py
+----------------
+A test harness and unittests for _util.py.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import with_statement
+
+import unittest
+from gnupg._parsers import UsageError
+
+## see PEP-366 http://www.python.org/dev/peps/pep-0366/
+
+print("NAME: %r" % __name__)
+print("PACKAGE: %r" % __package__)
+try:
+    import gnupg._parsers as parsers
+except (ImportError, ValueError) as ierr:
+    raise SystemExit(str(ierr))
+
+
+class TestKeyExpiryExtensionParser(unittest.TestCase):
+    """:class:`unittest.TestCase <TestCase>`s for python-gnupg util."""
+
+    def test_happy_path(self):
+        try:
+            parsers.KeyExtensionInterface("0")
+            parsers.KeyExtensionInterface("113")
+            parsers.KeyExtensionInterface("2w")
+            parsers.KeyExtensionInterface("3m")
+            parsers.KeyExtensionInterface("54y")
+        except UsageError:
+            self.fail('more than one digit, key extension option, raises exceptions')
+
+    def test_anything_that_is_not_w_y_m_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("2x")
+
+    def test_negative_number_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("-1")
+
+    def test_letters_without_a_number_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("w")
+
+    def test_letters_before_a_number_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("w3")
+
+    def test_more_than_w_is_not_allowed_option(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("2ww")
+
+    def test_more_than_m_is_not_allowed_option(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("7mm")
+
+    def test_more_than_y_is_not_allowed_option(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("9yy")


### PR DESCRIPTION
   [feat] adding key expiry date extension functionality

    - use --edit-key but confining it to key expiry through an interface
    - only allow for 1 subkey extension