### PR TITLE
[feat] Extend Key expiration and sign public key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,9 @@ test-run: test-before
 		listkeys \
 		genkey \
 		sign \
-		crypt
+		crypt \
+		expiration \
+		signing
 
 py3k-test-run: test-before
 	python3 $(TESTHANDLE) \
@@ -72,7 +74,9 @@ py3k-test-run: test-before
 		listkeys \
 		genkey \
 		sign \
-		crypt
+		crypt \
+		expiration \
+		signing
 
 coverage-run: test-before
 	coverage run --rcfile=".coveragerc" $(PYTHON) $(TESTHANDLE) \
@@ -83,7 +87,9 @@ coverage-run: test-before
 		listkeys \
 		genkeys \
 		sign \
-		crypt
+		crypt \
+		expiration \
+		signing
 
 py3k-coverage-run: test-before
 	coverage run --rcfile=".coveragerc" $(PYTHON3) $(TESTHANDLE) \
@@ -94,7 +100,9 @@ py3k-coverage-run: test-before
 		listkeys \
 		genkeys \
 		sign \
-		crypt
+		crypt \
+		expiration \
+		signing
 
 coverage-report:
 	coverage report --rcfile=".coveragerc"

--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -661,9 +661,6 @@ class GPGBase(object):
                     # for some stupid reason, considered fatal:
                     if value.find("trustdb.gpg") and value.find("No such file"):
                         result._handle_status('NEED_TRUSTDB', '')
-                elif 'key not found' in value:
-                    log.error("%s" % value)
-                    result._handle_status('KEY_NOT_FOUND', value)
             else:
                 if self.verbose:
                     log.info("%s" % line)

--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -150,6 +150,7 @@ class GPGBase(object):
                        'sign':     _parsers.Sign,
                        'verify':   _parsers.Verify,
                        'extension': _parsers.KeyExtensionResult,
+                       'signing': _parsers.KeySigningResult,
                        'packets':  _parsers.ListPackets }
 
     def __init__(self, binary=None, home=None, keyring=None, secring=None,
@@ -660,6 +661,9 @@ class GPGBase(object):
                     # for some stupid reason, considered fatal:
                     if value.find("trustdb.gpg") and value.find("No such file"):
                         result._handle_status('NEED_TRUSTDB', '')
+                elif 'key not found' in value:
+                    log.error("%s" % value)
+                    result._handle_status('KEY_NOT_FOUND', value)
             else:
                 if self.verbose:
                     log.info("%s" % line)

--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -149,8 +149,8 @@ class GPGBase(object):
                        'list':     _parsers.ListKeys,
                        'sign':     _parsers.Sign,
                        'verify':   _parsers.Verify,
-                       'extension': _parsers.KeyExtensionResult,
-                       'signing': _parsers.KeySigningResult,
+                       'expire':   _parsers.KeyExpirationResult,
+                       'signing':  _parsers.KeySigningResult,
                        'packets':  _parsers.ListPackets }
 
     def __init__(self, binary=None, home=None, keyring=None, secring=None,
@@ -943,7 +943,7 @@ class GPGBase(object):
 
         :param list hidden_recipients: A list of recipients that should have
             their keyids zero'd out in packet information.
-                                
+
         :param str cipher_algo: The cipher algorithm to use. To see available
                                 algorithms with your version of GnuPG, do:
                                 :command:`$ gpg --with-colons --list-config
@@ -1053,7 +1053,7 @@ class GPGBase(object):
                 log.info("Encrypted output written successfully.")
 
         return result
-    
+
     def _add_recipient_string(self, args, hidden_recipients, recipient):
         if isinstance(hidden_recipients, (list, tuple)):
             if [s for s in hidden_recipients if recipient in str(s)]:

--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -149,6 +149,7 @@ class GPGBase(object):
                        'list':     _parsers.ListKeys,
                        'sign':     _parsers.Sign,
                        'verify':   _parsers.Verify,
+                       'extension': _parsers.KeyExtensionResult,
                        'packets':  _parsers.ListPackets }
 
     def __init__(self, binary=None, home=None, keyring=None, secring=None,

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -833,19 +833,19 @@ def progress(status_code):
             return value
 
 
-class KeyExtensionInterface(object):
+class KeyExpirationInterface(object):
     """ Interface that guards against misuse of --edit-key combined with --command-fd"""
 
     def __init__(self, validity, passphrase=None):
         self._passphrase = passphrase
         self._validity_option = validity
-        self._clean_key_extension_option()
+        self._clean_key_expiration_option()
 
-    def _clean_key_extension_option(self):
-        """validates the extension option supplied"""
+    def _clean_key_expiration_option(self):
+        """validates the expiration option supplied"""
         allowed_entry = re.findall('^(\d+)(|w|m|y)$', self._validity_option)
         if not allowed_entry:
-            raise UsageError("Key extension option: %s is not valid" % self._validity_option)
+            raise UsageError("Key expiration option: %s is not valid" % self._validity_option)
 
     def _input_passphrase(self, _input):
         if self._passphrase:
@@ -860,18 +860,18 @@ class KeyExtensionInterface(object):
         sub_key_input = "key %d\nexpire\n%s\n" % (sub_key_number, self._validity_option)
         return self._input_passphrase(sub_key_input)
 
-    def gpg_interactive_input(self, extend_subkey=True):
+    def gpg_interactive_input(self, expire_subkey=True):
         """ processes series of inputs normally supplied on --edit-key but passed through stdin
             this ensures that no other --edit-key command is actually passing through.
         """
         _input = self._main_key_command()
-        if extend_subkey:
+        if expire_subkey:
             _input += self._sub_key_command()
         return "%ssave\n" % _input
 
 
-class KeyExtensionResult(object):
-    """Handle status messages for key expiry extension
+class KeyExpirationResult(object):
+    """Handle status messages for key expiry
         It does not really have a job, but just to conform to the API
     """
     def __init__(self, gpg):

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -869,12 +869,13 @@ class KeyExtensionResult(object):
 
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
-        if key in ("USERID_HINT", "NEED_PASSPHRASE",
-                   "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
+        if key in ("USERID_HINT", "NEED_PASSPHRASE", "KEYEXPIRED",
+                   "SIGEXPIRED", "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
             pass
         elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE"):
             self.status = key.replace("_", " ").lower()
         else:
+            self.status = 'failed'
             raise ValueError("Unknown status message: %r" % key)
 
 

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -909,7 +909,7 @@ class KeySigningResult(object):
         if key in ("USERID_HINT", "NEED_PASSPHRASE", "ALREADY_SIGNED",
                    "GOOD_PASSPHRASE", "GOT_IT", "GET_BOOL"):
             pass
-        elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE", "KEY_NOT_FOUND"):
+        elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE"):
             self.status = "%s: %s" % (key.replace("_", " ").lower(), value)
         else:
             self.status = 'failed'

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -836,16 +836,16 @@ def progress(status_code):
 class KeyExpirationInterface(object):
     """ Interface that guards against misuse of --edit-key combined with --command-fd"""
 
-    def __init__(self, validity, passphrase=None):
+    def __init__(self, expiration_time, passphrase=None):
         self._passphrase = passphrase
-        self._validity_option = validity
+        self._expiration_time = expiration_time
         self._clean_key_expiration_option()
 
     def _clean_key_expiration_option(self):
         """validates the expiration option supplied"""
-        allowed_entry = re.findall('^(\d+)(|w|m|y)$', self._validity_option)
+        allowed_entry = re.findall('^(\d+)(|w|m|y)$', self._expiration_time)
         if not allowed_entry:
-            raise UsageError("Key expiration option: %s is not valid" % self._validity_option)
+            raise UsageError("Key expiration option: %s is not valid" % self._expiration_time)
 
     def _input_passphrase(self, _input):
         if self._passphrase:
@@ -853,11 +853,11 @@ class KeyExpirationInterface(object):
         return _input
 
     def _main_key_command(self):
-        main_key_input = "expire\n%s\n" % self._validity_option
+        main_key_input = "expire\n%s\n" % self._expiration_time
         return self._input_passphrase(main_key_input)
 
     def _sub_key_command(self, sub_key_number=1):
-        sub_key_input = "key %d\nexpire\n%s\n" % (sub_key_number, self._validity_option)
+        sub_key_input = "key %d\nexpire\n%s\n" % (sub_key_number, self._expiration_time)
         return self._input_passphrase(sub_key_input)
 
     def gpg_interactive_input(self, expire_subkey=True):
@@ -884,7 +884,7 @@ class KeyExpirationResult(object):
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
         if key in ("USERID_HINT", "NEED_PASSPHRASE",
-                    "GET_HIDDEN", "SIGEXPIRED", "KEYEXPIRED",
+                   "GET_HIDDEN", "SIGEXPIRED", "KEYEXPIRED",
                    "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
             pass
         elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE"):

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -509,7 +509,6 @@ def _get_options_group(group=None):
                                    '--status-fd',
                                    '--verify-options',
                                    '--command-fd',
-                                   '--passphrase',
                                ])
     #: These have their own parsers and don't really fit into a group
     other_options = frozenset(['--debug-level',
@@ -836,7 +835,8 @@ def progress(status_code):
 class KeyExtensionInterface(object):
     """ Interface that guards against misuse of --edit-key combined with --command-fd"""
 
-    def __init__(self, validity):
+    def __init__(self, validity, passphrase=None):
+        self._passphrase = passphrase
         self._validity_option = validity
         self._clean_key_extension_option()
 
@@ -846,13 +846,26 @@ class KeyExtensionInterface(object):
         if not allowed_entry:
             raise UsageError("Key extension option: %s is not valid" % self._validity_option)
 
+    def _input_passphrase(self, _input):
+        if self._passphrase:
+            return  "%s%s\n" % (_input, self._passphrase)
+        return _input
+
+    def _main_key_command(self):
+        main_key_input = "expire\n%s\n" % self._validity_option
+        return self._input_passphrase(main_key_input)
+
+    def _sub_key_command(self, sub_key_number=1):
+        sub_key_input = "key %d\nexpire\n%s\n" % (sub_key_number, self._validity_option)
+        return self._input_passphrase(sub_key_input)
+
     def gpg_interactive_input(self, extend_subkey=True):
         """ processes series of inputs normally supplied on --edit-key but passed through stdin
             this ensures that no other --edit-key command is actually passing through.
         """
-        _input = "expire\n%s\n" % self._validity_option
+        _input = self._main_key_command()
         if extend_subkey:
-            _input = "%skey 1\nexpire\n%s\n" % (_input, self._validity_option)
+            _input += self._sub_key_command()
         return "%ssave\n" % _input
 
 
@@ -869,8 +882,9 @@ class KeyExtensionResult(object):
 
         :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
         """
-        if key in ("USERID_HINT", "NEED_PASSPHRASE", "KEYEXPIRED",
-                   "SIGEXPIRED", "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
+        if key in ("USERID_HINT", "NEED_PASSPHRASE",
+                    "GET_HIDDEN", "SIGEXPIRED", "KEYEXPIRED",
+                   "GOOD_PASSPHRASE", "GOT_IT", "GET_LINE"):
             pass
         elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE"):
             self.status = key.replace("_", " ").lower()

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -849,24 +849,26 @@ class KeyExpirationInterface(object):
 
     def _input_passphrase(self, _input):
         if self._passphrase:
-            return  "%s%s\n" % (_input, self._passphrase)
+            return "%s%s\n" % (_input, self._passphrase)
         return _input
 
     def _main_key_command(self):
         main_key_input = "expire\n%s\n" % self._expiration_time
         return self._input_passphrase(main_key_input)
 
-    def _sub_key_command(self, sub_key_number=1):
+    def _sub_key_command(self, sub_key_number):
         sub_key_input = "key %d\nexpire\n%s\n" % (sub_key_number, self._expiration_time)
         return self._input_passphrase(sub_key_input)
 
-    def gpg_interactive_input(self, expire_subkey=True):
+    def gpg_interactive_input(self, sub_keys_number):
         """ processes series of inputs normally supplied on --edit-key but passed through stdin
             this ensures that no other --edit-key command is actually passing through.
         """
+        deselect_sub_key = "key 0\n"
+
         _input = self._main_key_command()
-        if expire_subkey:
-            _input += self._sub_key_command()
+        for sub_key_number in range(1, sub_keys_number + 1):
+            _input += self._sub_key_command(sub_key_number) + deselect_sub_key
         return "%ssave\n" % _input
 
 

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -912,7 +912,9 @@ class KeySigningResult(object):
         elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE", "KEY_NOT_FOUND"):
             self.status = "%s: %s" % (key.replace("_", " ").lower(), value)
         else:
+            self.status = 'failed'
             raise ValueError("Key signing, unknown status message: %r ::%s" % (key, value))
+
 
 class GenKey(object):
     """Handle status messages for key generation.

--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -500,7 +500,8 @@ def _get_options_group(group=None):
                              '--recipient',
                              '--recv-keys',
                              '--send-keys',
-                             '--edit-key'
+                             '--edit-key',
+                             '--sign-key',
                              ])
     #: These options expect value which are left unchecked, though still run
     #: through :func:`_fix_unsafe`.
@@ -892,6 +893,26 @@ class KeyExtensionResult(object):
             self.status = 'failed'
             raise ValueError("Unknown status message: %r" % key)
 
+
+class KeySigningResult(object):
+    """Handle status messages for key singing
+    """
+    def __init__(self, gpg):
+        self._gpg = gpg
+        self.status = 'ok'
+
+    def _handle_status(self, key, value):
+        """Parse a status code from the attached GnuPG process.
+
+        :raises: :exc:`~exceptions.ValueError` if the status message is unknown.
+        """
+        if key in ("USERID_HINT", "NEED_PASSPHRASE", "ALREADY_SIGNED",
+                   "GOOD_PASSPHRASE", "GOT_IT", "GET_BOOL"):
+            pass
+        elif key in ("BAD_PASSPHRASE", "MISSING_PASSPHRASE", "KEY_NOT_FOUND"):
+            self.status = "%s: %s" % (key.replace("_", " ").lower(), value)
+        else:
+            raise ValueError("Key signing, unknown status message: %r ::%s" % (key, value))
 
 class GenKey(object):
     """Handle status messages for key generation.

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -579,14 +579,12 @@ class GPG(GPGBase):
                     the new expiration date can be obtained by .list_keys()
         """
 
-        args = ["--batch"]
-        if passphrase:
-            args.append("--passphrase %s" % passphrase)
-        args.extend(["--command-fd 0", "--edit-key %s" % keyid])
+        args = ["--command-fd 0", "--edit-key %s" % keyid]
 
         p = self._open_subprocess(args)
         result = self._result_map['extension'](self)
-        extension_input = KeyExtensionInterface(validity).gpg_interactive_input(extend_subkey)
+        passphrase = passphrase.encode(self._encoding) if passphrase else passphrase
+        extension_input = KeyExtensionInterface(validity, passphrase).gpg_interactive_input(extend_subkey)
         p.stdin.write(extension_input)
         self._collect_output(p, result, stdin=p.stdin)
         return result

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -615,12 +615,12 @@ class GPG(GPGBase):
                 the new expiration date can be obtained by .list_keys()
         """
 
-        args = ["--command-fd 0", "--edit-key %s" % keyid]
-
-        p = self._open_subprocess(args)
         result = self._result_map['expire'](self)
         passphrase = passphrase.encode(self._encoding) if passphrase else passphrase
         expiration_input = KeyExpirationInterface(expiration_time, passphrase).gpg_interactive_input(expire_subkey)
+
+        args = ["--command-fd 0", "--edit-key %s" % keyid]
+        p = self._open_subprocess(args)
         p.stdin.write(expiration_input)
         self._collect_output(p, result, stdin=p.stdin)
         return result

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -40,7 +40,7 @@ import textwrap
 from .         import _util
 from .         import _trust
 from ._meta    import GPGBase
-from ._parsers import _fix_unsafe
+from ._parsers import _fix_unsafe, KeyExtensionInterface
 from ._util    import _is_list_or_tuple
 from ._util    import _is_stream
 from ._util    import _make_binary_stream
@@ -557,6 +557,39 @@ class GPG(GPGBase):
             keyword = L[0]
             if keyword in valid_keywords:
                 getattr(result, keyword)(L)
+
+    def extend_key(self, keyid, validity='1y', passphrase=None, extend_subkey=True):
+        """Extends a GnuPG key by passing in new validity period (from now) through
+            subprocess's stdin
+
+        >>> import gnupg
+        >>> gpg = gnupg.GPG(homedir="doctests")
+        >>> key_input = gpg.gen_key_input()
+        >>> key = gpg.gen_key(key_input)
+        >>> gpg.extend_key(key.fingerprint, '2w', 'good passphrase')
+
+        :param str keyid: key shortID, longID, email_address or fingerprint
+        :param str validity: 0 or number of days (d), or weeks (*w) , or months (*m) or years (*y)
+                               to extend the key, from its creation date.
+        :param str passphrase: passphrase used when creating the key, leave None otherwise
+        :param bool extend_subkey: to indicate whether the first subkey will also extended
+                by the same period --default is True
+
+        :returns: The result giving status of the extension...
+                    the new expiration date can be obtained by .list_keys()
+        """
+
+        args = ["--batch"]
+        if passphrase:
+            args.append("--passphrase %s" % passphrase)
+        args.extend(["--command-fd 0", "--edit-key %s" % keyid])
+
+        p = self._open_subprocess(args)
+        result = self._result_map['extension'](self)
+        extension_input = KeyExtensionInterface(validity).gpg_interactive_input(extend_subkey)
+        p.stdin.write(extension_input)
+        self._collect_output(p, result, stdin=p.stdin)
+        return result
 
     def gen_key(self, input):
         """Generate a GnuPG key through batch file key generation. See

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -496,7 +496,7 @@ class GPG(GPGBase):
                         result)
         return result
 
-    def sign_key(self, keyid, passphrase=None):
+    def sign_key(self, keyid, default_key=None, passphrase=None):
         """ sign (an imported) public key - keyid, with default secret key
 
         >>> import gnupg
@@ -519,6 +519,10 @@ class GPG(GPGBase):
             passphrase_arg = "--passphrase-fd 0"
             input_command = "%s\n" % passphrase
             args.append(passphrase_arg)
+
+        if default_key:
+            args.append(str("--default-key %s" % default_key))
+
         args.extend(["--command-fd 0", "--sign-key %s" % keyid])
 
         p = self._open_subprocess(args)

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -616,7 +616,12 @@ class GPG(GPGBase):
         """
 
         passphrase = passphrase.encode(self._encoding) if passphrase else passphrase
-        sub_keys_number = len(self.list_sigs(keyid)[0]['subkeys']) if expire_subkeys else 0
+
+        try:
+            sub_keys_number = len(self.list_sigs(keyid)[0]['subkeys']) if expire_subkeys else 0
+        except IndexError:
+            sub_keys_number = 0
+
         expiration_input = KeyExpirationInterface(expiration_time, passphrase).gpg_interactive_input(sub_keys_number)
 
         args = ["--command-fd 0", "--edit-key %s" % keyid]

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -1240,7 +1240,7 @@ authentication."""
         res = alice_public.results[-1:][0]
         alice_pfpr = str(res['fingerprint'])
         alice.close()
-        
+
         bob = open(os.path.join(_files, 'test_key_2.pub'))
         bob_pub = bob.read()
         bob_public = self.gpg.import_keys(bob_pub)
@@ -1261,7 +1261,7 @@ authentication."""
                   % alice_pfpr)
 
         self.assertNotEquals(message, encrypted)
-        ## We expect Alice's key to be hidden (returned as zero's) and Bob's 
+        ## We expect Alice's key to be hidden (returned as zero's) and Bob's
         ## key to be there.
         expected_values = ["0000000000000000", "E0ED97345F2973D6"]
         self.assertEquals(expected_values, self.gpg.list_packets(encrypted).encrypted_to)
@@ -1490,14 +1490,14 @@ know, maybe you shouldn't be doing it in the first place.
             encrypted_message = fh.read()
             self.assertTrue(b"-----BEGIN PGP MESSAGE-----" in encrypted_message)
 
-    def test_key_extension(self):
-        """Test that extending key expiry date succeeds."""
+    def test_key_expiration(self):
+        """Test that changing key expiration date succeeds."""
         today = datetime.date.today()
         date_format = '%Y-%m-%d'
         tomorrow = today + datetime.timedelta(days=1)
         key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
 
-        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase="haha.hehe")
+        self.gpg.expire(key.fingerprint, expiration_time='1w', passphrase="haha.hehe")
         next_week = today + datetime.timedelta(weeks=1)
 
         current_keys = self.gpg.list_keys()
@@ -1505,8 +1505,8 @@ know, maybe you shouldn't be doing it in the first place.
             self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
             self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
 
-    def test_passphrase_with_space_on_key_extension(self):
-        """Test that wrong passphrase does not allow extension."""
+    def test_passphrase_with_space_on_key_expiration(self):
+        """Test that passphrase with space does allow changing expiration."""
         today = datetime.date.today()
         date_format = '%Y-%m-%d'
         tomorrow = today + datetime.timedelta(days=1)
@@ -1514,7 +1514,7 @@ know, maybe you shouldn't be doing it in the first place.
         key = self.generate_key("Haha", "ho.ho", passphrase=password_with_space,
                                 expire_date=tomorrow.strftime(date_format))
 
-        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase=password_with_space)
+        self.gpg.expire(key.fingerprint, expiration_time='1w', passphrase=password_with_space)
         next_week = today + datetime.timedelta(weeks=1)
 
         current_keys = self.gpg.list_keys()
@@ -1522,30 +1522,30 @@ know, maybe you shouldn't be doing it in the first place.
             self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
             self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
 
-    def test_wrong_passphrase_on_key_extension(self):
-        """Test that wrong passphrase does not allow extension."""
+    def test_wrong_passphrase_on_key_expiration(self):
+        """Test that wrong passphrase does not allow changing expiration."""
         today = datetime.date.today()
         date_format = '%Y-%m-%d'
         tomorrow = today + datetime.timedelta(days=1)
         key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
 
-        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase="wrong passphrase")
+        self.gpg.expire(key.fingerprint, expiration_time='1w', passphrase="wrong passphrase")
 
         current_keys = self.gpg.list_keys()
         for fecthed_key in current_keys:
             self.assertEqual(tomorrow, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
             self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
 
-    def test_invalid_extension_period_throws_exception_on_key_extension(self):
-        """Test that key extension has to be positive value"""
+    def test_invalid_expiration_time_throws_exception_on_key_expiration(self):
+        """Test that changing key expiration has to be positive value"""
         today = datetime.date.today()
         date_format = '%Y-%m-%d'
         tomorrow = today + datetime.timedelta(days=1)
         key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
 
-        invalid_extension_option = "-1w"
+        invalid_expiration_option = "-1w"
         with self.assertRaises(_parsers.UsageError):
-            self.gpg.extend_key(key.fingerprint, validity=invalid_extension_option, passphrase="haha.hehe")
+            self.gpg.expire(key.fingerprint, expiration_time=invalid_expiration_option, passphrase="haha.hehe")
 
     def test_key_signing(self):
         """Test that signing a key with default key succeeds."""
@@ -1673,10 +1673,10 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
            'recvkeys': set(['test_recv_keys_default']),
            'revokekey': set(['test_list_revoked_key',
                              'test_revoke_and_not_revoked_key']),
-           'extend': set(['test_key_extension',
-                          'test_passphrase_with_space_on_key_extension',
-                          'test_wrong_passphrase_on_key_extension',
-                          'test_invalid_extension_period_throws_exception_on_key_extension']),
+           'expiration': set(['test_key_expiration',
+                          'test_passphrase_with_space_on_key_expiration',
+                          'test_wrong_passphrase_on_key_expiration',
+                          'test_invalid_expiration_time_throws_exception_on_key_expiration']),
            'signing': set(['test_key_signing',
                            'test_key_signing_with_different_key',
                            'test_signing_an_already_signed_key_does_nothing_and_is_okay',

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -1559,6 +1559,18 @@ know, maybe you shouldn't be doing it in the first place.
         self.assertEqual('ok', result.status)
         self.assertIn(default_key_pair.fingerprint[-16:], hehe_sigs_keyids)
 
+    def test_key_signing_with_different_key(self):
+        """Test that signing a key with default key succeeds."""
+        key1 = self.generate_key("haha", "ha.ha")
+        key2 = self.generate_key("hehe", "he.he", passphrase="hehe.hehe")
+
+        result = self.gpg.sign_key(key1.fingerprint, default_key=key2, passphrase="hehe.hehe")
+
+        key1_sigs_keyids = self._get_sigs(key1.fingerprint[-16:])
+
+        self.assertEqual('ok', result.status)
+        self.assertIn(key2.fingerprint[-16:], key1_sigs_keyids)
+
     def _get_sigs(self, target_keyid):
         sigs = self.gpg.list_sigs()
         hehe_sigs = filter(lambda sig: sig['keyid'] == target_keyid, sigs)[0]
@@ -1666,6 +1678,7 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                           'test_wrong_passphrase_on_key_extension',
                           'test_invalid_extension_period_throws_exception_on_key_extension']),
            'signing': set(['test_key_signing',
+                           'test_key_signing_with_different_key',
                            'test_signing_an_already_signed_key_does_nothing_and_is_okay',
                            'test_signing_key_with_wrong_password']),
 }

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -1505,6 +1505,23 @@ know, maybe you shouldn't be doing it in the first place.
             self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
             self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
 
+    def test_passphrase_with_space_on_key_extension(self):
+        """Test that wrong passphrase does not allow extension."""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        password_with_space = "passphrase with space"
+        key = self.generate_key("Haha", "ho.ho", passphrase=password_with_space,
+                                expire_date=tomorrow.strftime(date_format))
+
+        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase=password_with_space)
+        next_week = today + datetime.timedelta(weeks=1)
+
+        current_keys = self.gpg.list_keys()
+        for fecthed_key in current_keys:
+            self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
+            self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
+
     def test_wrong_passphrase_on_key_extension(self):
         """Test that wrong passphrase does not allow extension."""
         today = datetime.date.today()
@@ -1602,6 +1619,7 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
            'revokekey': set(['test_list_revoked_key',
                              'test_revoke_and_not_revoked_key']),
            'extend': set(['test_key_extension',
+                          'test_passphrase_with_space_on_key_extension',
                           'test_wrong_passphrase_on_key_extension',
                           'test_invalid_extension_period_throws_exception_on_key_extension']),
 }

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import with_statement
 
+import datetime
 from argparse   import ArgumentParser
 from codecs     import open as open
 from functools  import wraps
@@ -430,6 +431,7 @@ class GPGTestCase(unittest.TestCase):
         os.remove(outfile)
 
     def generate_key_input(self, real_name, email_domain, key_length=None,
+                           expire_date=1,
                            key_type=None, subkey_type=None, passphrase=None):
         """Generate a GnuPG batch file for key unattended key creation."""
         name = real_name.lower().replace(' ', '')
@@ -439,7 +441,7 @@ class GPGTestCase(unittest.TestCase):
 
         batch = {'Key-Type': key_type,
                  'Key-Length': key_length,
-                 'Expire-Date': 1,
+                 'Expire-Date': expire_date,
                  'Name-Real': '%s' % real_name,
                  'Name-Email': ("%s@%s" % (name, email_domain))}
 
@@ -1488,6 +1490,46 @@ know, maybe you shouldn't be doing it in the first place.
             encrypted_message = fh.read()
             self.assertTrue(b"-----BEGIN PGP MESSAGE-----" in encrypted_message)
 
+    def test_key_extension(self):
+        """Test that extending key expiry date succeeds."""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
+
+        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase="haha.hehe")
+        next_week = today + datetime.timedelta(weeks=1)
+
+        current_keys = self.gpg.list_keys()
+        for fecthed_key in current_keys:
+            self.assertEqual(next_week, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
+            self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
+
+    def test_wrong_passphrase_on_key_extension(self):
+        """Test that wrong passphrase does not allow extension."""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
+
+        self.gpg.extend_key(key.fingerprint, validity='1w', passphrase="wrong passphrase")
+
+        current_keys = self.gpg.list_keys()
+        for fecthed_key in current_keys:
+            self.assertEqual(tomorrow, datetime.date.fromtimestamp(int(fecthed_key['expires'])))
+            self.assertEqual(key.fingerprint, fecthed_key['fingerprint'])
+
+    def test_invalid_extension_period_throws_exception_on_key_extension(self):
+        """Test that key extension has to be positive value"""
+        today = datetime.date.today()
+        date_format = '%Y-%m-%d'
+        tomorrow = today + datetime.timedelta(days=1)
+        key = self.generate_key("Haha", "ho.ho", passphrase="haha.hehe", expire_date=tomorrow.strftime(date_format))
+
+        invalid_extension_option = "-1w"
+        with self.assertRaises(_parsers.UsageError):
+            self.gpg.extend_key(key.fingerprint, validity=invalid_extension_option, passphrase="haha.hehe")
+
 
 suites = { 'parsers': set(['test_parsers_fix_unsafe',
                            'test_parsers_fix_unsafe_semicolon',
@@ -1559,6 +1601,9 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
            'recvkeys': set(['test_recv_keys_default']),
            'revokekey': set(['test_list_revoked_key',
                              'test_revoke_and_not_revoked_key']),
+           'extend': set(['test_key_extension',
+                          'test_wrong_passphrase_on_key_extension',
+                          'test_invalid_extension_period_throws_exception_on_key_extension']),
 }
 
 def main(args):

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -1591,17 +1591,6 @@ know, maybe you shouldn't be doing it in the first place.
         self.assertEqual('bad passphrase: %s' % default_key_pair.fingerprint[-16:], result.status)
         self.assertNotIn(default_key_pair.fingerprint[-16:], hehe_sigs_keyids)
 
-    def test_signing_a_non_existing_or_non_imported_key_fails(self):
-        """Test that signing a non existing or not imported key is logged."""
-        default_key_pair = self.generate_key("haha", "ha.ha", passphrase="haha.haha")
-        not_default_fpr_ending = 'B' if default_key_pair.fingerprint[-1] == 'A' else 'A'
-        non_existing_key_fpr = '%s%s' % (default_key_pair.fingerprint[:-1], not_default_fpr_ending)
-
-        result = self.gpg.sign_key(non_existing_key_fpr, passphrase="haha.haha")
-
-        self.assertEqual('key not found: "%s" not found: public key not found' % non_existing_key_fpr,
-                         result.status)
-
 suites = { 'parsers': set(['test_parsers_fix_unsafe',
                            'test_parsers_fix_unsafe_semicolon',
                            'test_parsers_is_hex_valid',
@@ -1678,7 +1667,6 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                           'test_invalid_extension_period_throws_exception_on_key_extension']),
            'signing': set(['test_key_signing',
                            'test_signing_an_already_signed_key_does_nothing_and_is_okay',
-                           'test_signing_a_non_existing_or_non_imported_key_fails',
                            'test_signing_key_with_wrong_password']),
 }
 

--- a/gnupg/test/test_parsers.py
+++ b/gnupg/test/test_parsers.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of python-gnupg, a Python interface to GnuPG.
+# Copyright © 2013 Isis Lovecruft, <isis@leap.se> 0xA3ADB67A2CDB8B35
+#           © 2013 Andrej B.
+#           © 2013 LEAP Encryption Access Project
+#           © 2008-2012 Vinay Sajip
+#           © 2005 Steve Traugott
+#           © 2004 A.M. Kuchling
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the included LICENSE file for details.
+
+"""test_util.py
+----------------
+A test harness and unittests for _util.py.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import with_statement
+
+import unittest
+from gnupg._parsers import UsageError
+
+## see PEP-366 http://www.python.org/dev/peps/pep-0366/
+
+print("NAME: %r" % __name__)
+print("PACKAGE: %r" % __package__)
+try:
+    import gnupg._parsers as parsers
+except (ImportError, ValueError) as ierr:
+    raise SystemExit(str(ierr))
+
+
+class TestKeyExpiryExtensionParser(unittest.TestCase):
+    """:class:`unittest.TestCase <TestCase>`s for python-gnupg util."""
+
+    def test_happy_path(self):
+        try:
+            parsers.KeyExtensionInterface("0")
+            parsers.KeyExtensionInterface("113")
+            parsers.KeyExtensionInterface("2w")
+            parsers.KeyExtensionInterface("3m")
+            parsers.KeyExtensionInterface("54y")
+        except UsageError:
+            self.fail('more than one digit, key extension option, raises exceptions')
+
+    def test_anything_that_is_not_w_y_m_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("2x")
+
+    def test_negative_number_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("-1")
+
+    def test_letters_without_a_number_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("w")
+
+    def test_letters_before_a_number_is_not_allowed(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("w3")
+
+    def test_more_than_w_is_not_allowed_option(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("2ww")
+
+    def test_more_than_m_is_not_allowed_option(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("7mm")
+
+    def test_more_than_y_is_not_allowed_option(self):
+        with self.assertRaises(UsageError):
+            parsers.KeyExtensionInterface("9yy")


### PR DESCRIPTION
Key expiry date extension:
- use --edit-key but confining it to key expiry through an interface
- only allow for 1 subkey extension

Public key signing:
- using --sign-key and passing passphrase and confirmation through stdin ( file descriptor 0)
- does not cater for key signing from non-default secret keys