### PR TITLE
Bail if version string is bogus

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -32,6 +32,7 @@ import encodings
 import locale
 import os
 import platform
+import re
 import shlex
 import subprocess
 import sys
@@ -52,6 +53,8 @@ from ._util import s
 from ._parsers import _check_preferences
 from ._parsers import _sanitise_list
 from ._util    import log
+
+_VERSION_RE = re.compile('^\d+\.\d+\.\d+$')
 
 
 class GPGMeta(type):
@@ -514,8 +517,12 @@ class GPGBase(object):
                            "Are you sure you specified the corrent (and full) "
                            "path to the gpg binary?"))
 
-        version_line = str(result.data).partition(':version:')[2]
+        version_line = result.data.partition(b':version:')[2].decode()
+        if not version_line:
+            raise RuntimeError("Got invalid version line from gpg: %s\n" % result.data)
         self.binary_version = version_line.split('\n')[0]
+        if not _VERSION_RE.match(self.binary_version):
+            raise RuntimeError("Got invalid version line from gpg: %s\n" % self.binary_version)
         log.debug("Using GnuPG version %s" % self.binary_version)
 
     def _make_args(self, args, passphrase=False):

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -51,6 +51,11 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 else:
     import unittest
 
+if sys.version_info[0] == 2:
+    import mock
+else:
+    from unittest import mock
+
 import gnupg
 
 ## see PEP-366 http://www.python.org/dev/peps/pep-0366/
@@ -383,6 +388,23 @@ class GPGTestCase(unittest.TestCase):
         self.assertTrue(len(args) == 6)
         for na in not_allowed:
             self.assertNotIn(na, args)
+
+    def test_gpg_version_malformed(self):
+        old_sub = gnupg._meta.subprocess.Popen
+        new_sub = mock.MagicMock()
+        new_sub.return_value.stdout = io.BytesIO(b"blah blah blah")
+        new_sub.return_value.returncode = 0
+        gnupg._meta.subprocess.Popen = new_sub
+
+        try:
+            with self.assertRaises(RuntimeError):
+                self.gpg._check_sane_and_get_gpg_version()
+
+            new_sub.return_value.stdout = io.BytesIO(b"foo:version:bar")
+            with self.assertRaises(RuntimeError):
+                self.gpg._check_sane_and_get_gpg_version()
+        finally:
+            gnupg._meta.subprocess.Popen = old_sub
 
     def test_list_keys_initial_public(self):
         """Test that initially there are no public keys."""
@@ -1507,7 +1529,8 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                          'test_list_keys_initial_public',
                          'test_list_keys_initial_secret',
                          'test_make_args_drop_protected_options',
-                         'test_make_args']),
+                         'test_make_args',
+                         'test_gpg_version_malformed']),
            'genkey': set(['test_gen_key_input',
                           'test_rsa_key_generation',
                           'test_rsa_key_generation_with_unicode',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,10 @@ def python26():
         return True
     return False
 
+def python2():
+    """Returns True if we're running on py2"""
+    return sys.version[:1] ==  "2"
+
 def get_requirements():
     """Extract the list of requirements from our requirements.txt.
 
@@ -82,6 +86,10 @@ def get_requirements():
     if python26():
         # Required to make `collections.OrderedDict` available on Python<=2.6
         requirements.append('ordereddict==1.1#a0ed854ee442051b249bfad0f638bbec')
+
+    if python2():
+        # mock isn't included in py2
+        requirements.append('mock==2.0.0')
 
     # Don't try to install psutil on PyPy:
     if _isPyPy:


### PR DESCRIPTION
Hey there!

This fixes some bugs in version-parsing, and I *think* addresses the issue #144.

This ensures that the version returned by gnupg is valid, and bails if it's not. Tested in 2.7 and 3.5 on OpenBSD. It looks like there may be some cases where the output of `gpg` is misinterpreted as a string rather than a bytestring, but I'm still looking.

Heads up, in py2.x, this introduces an additional dependency on `mock`, since it's only introduced in the stdlib in py3.

Thanks!