### PR TITLE
bugfix GPG.sign() & GPG.verify_file()

### DIFF
--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -240,7 +240,11 @@ def _copy_data(instream, outstream):
             break
 
         sent += len(data)
-        encoded = binary(data)
+        if ((_py3k and isinstance(data, str)) or
+            (not _py3k and isinstance(data, basestring))):
+            encoded = binary(data)
+        else:
+            encoded = data
         log.debug("Sending %d bytes of data..." % sent)
         log.debug("Encoded data (type %s):\n%s" % (type(encoded), encoded))
 


### PR DESCRIPTION
Probabry same problem #169 is occurring in GPG.verify_file()

https://gist.github.com/mugwort-rc/ca27e54853d8b8ef5f204908ae4e92a5#file-failure-log

```
>>> set([gnupg._util.binary(bytes([x])) for x in range(0x80, 0x100)])
{b'\xef\xbf\xbd'}
```