### PR TITLE
Silence homedir warnings from gpg

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -652,7 +652,11 @@ class GPGBase(object):
 
                 # Log gpg's userland messages at our own levels:
                 if keyword.upper().startswith("WARNING"):
-                    log.warn("%s" % value)
+                    # Silence warnings from gpg we're supposed to ignore
+                    ignore = (self.ignore_homedir_permissions
+                        and 'unsafe ownership on homedir' in value)
+                    if not ignore:
+                        log.warn("%s" % value)
                 elif keyword.upper().startswith("FATAL"):
                     log.critical("%s" % value)
                     # Handle the gpg2 error where a missing trustdb.gpg is,


### PR DESCRIPTION
If run from root but with EUID set to a given user, python-gnupg
correctly creates the home directory and initializes it for the user,
but gpg2 still issues a warning about invalid permissions on the
directory since it uses the UID for detection and not the EUID.

This got a wontfix response on the Debian bugtracker [1], but that was
based on a weirder case of running the gpg binary SUID root, so might
be hopes of getting it fixed upstream.

This fix silences the warning only if ignore_homedir_permissions is
set, which should enable getting rid of the warning in environments
where it doesn't make sense.

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=835629