### PR TITLE
Handle PROGRESS status message

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -990,6 +990,8 @@ class Sign(object):
                  self.status += " on {}".format(str(value))
         elif key == "NODATA":
             self.status = nodata(value)
+        elif key == "PROGRESS":
+            self.status = progress(value.split(' ', 1)[0])
         else:
             raise ValueError("Unknown status message: %r" % key)
 


### PR DESCRIPTION
Will hide this exception when GPG.sign() is called

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "gnupg/_meta.py", line 648, in _read_response
    result._handle_status(keyword, value)
  File "gnupg/_parsers.py", line 994, in _handle_status
    raise ValueError("Unknown status message: %r" % key)
ValueError: Unknown status message: u'PROGRESS'
```