### PR TITLE
Fixing Windows issues

### DIFF
--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -708,7 +708,7 @@ def _which(executable, flags=os.X_OK, abspath_only=False, disallow_symlinks=Fals
         return True
 
     result = []
-    exts = filter(None, os.environ.get('PATHEXT', '').split(os.pathsep))
+    exts = list(filter(None, os.environ.get('PATHEXT', '').split(os.pathsep)))
     path = os.environ.get('PATH', None)
     if path is None:
         return []

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -1092,7 +1092,7 @@ generate keys. Please see
         if output:  # write the output to a file with the specified name
             if os.path.exists(output):
                 os.remove(output) # to avoid overwrite confirmation message
-            args.append('--output %s' % output)
+            args.append('--output %s' % _fix_unsafe(output))
         if always_trust:
             args.append("--always-trust")
         result = self._result_map['crypt'](self)
@@ -1136,7 +1136,7 @@ class GPGUtilities(object):
         result = self._result_map['list'](self)
         log.debug('send_keys: %r', keyids)
         data = _util._make_binary_stream("", self._encoding)
-        args = ['--keyserver', keyserver, '--send-keys']
+        args = ['--keyserver', _fix_unsafe(keyserver), '--send-keys']
         args.extend(keyids)
         self._handle_io(args, data, result, binary=True)
         log.debug('send_keys result: %r', result.__dict__)

--- a/gnupg/test/test_gnupg.py
+++ b/gnupg/test/test_gnupg.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of python-gnupg, a Python interface to GnuPG.
-# Copyright © 2013 Isis Lovecruft, <isis@leap.se> 0xA3ADB67A2CDB8B35
+# Copyright @ 2017 Nicolas Bruot <bruotn@gmail.com>
+#           © 2013 Isis Lovecruft, <isis@leap.se> 0xA3ADB67A2CDB8B35
 #           © 2013 Andrej B.
 #           © 2013 LEAP Encryption Access Project
 #           © 2008-2012 Vinay Sajip
@@ -366,11 +367,11 @@ class GPGTestCase(unittest.TestCase):
         self.gpg.options = ['--tyrannosaurus-rex', '--stegosaurus', '--lock-never', '--trust-model always']
         gpg_binary_path = _util._find_binary('gpg')
         cmd = self.gpg._make_args(None, False)
-        expected = [gpg_binary_path,
+        expected = [_parsers._fix_unsafe(gpg_binary_path),
                     '--no-options --no-emit-version --no-tty --status-fd 2',
-                    '--homedir "%s"' % self.homedir,
-                    '--no-default-keyring --keyring %s' % self.keyring,
-                    '--secret-keyring %s' % self.secring,
+                    '--homedir %s' % _parsers._fix_unsafe(self.homedir),
+                    '--no-default-keyring --keyring %s' % _parsers._fix_unsafe(self.keyring),
+                    '--secret-keyring %s' % _parsers._fix_unsafe(self.secring),
                     '--no-use-agent',
                     '--lock-never',
                     '--trust-model always']


### PR DESCRIPTION
Here are a few fixes that make python-gnupg work on Windows.

The main change is about paths: the strategy in this PR is to escape the paths as late as possible in the code.

According to my tests, this solves #199 and #204 on Python 2 & 3.

Below is a summary of the tests results. On Windows, since the GPG class could not be instantiated before, the tests are necessarily better... On Debian, some tests are already failing on the master branch and many even make the process hang (example with "test_gnupg.py crypt" in note [11] of attached file). When removing the ones that make the tests hang, I saw no notable difference between the tests on the master branch and this pull request.

Tests summary (see attached log for the numbered notes):

Python 2.7.13, GnuPG 1.4.22, this pull request (ea96545369d63bdc6a9799cbcb7015edd45be4eb):

  - parsers: OK
  - encodings: OK
  - basic: OK
  - genkey: OK
  - sign: 2 fails out of 11 [1]
  - crypt: 7 fails, 1 error out of 18 [2]
  - listkeys: OK
  - keyrings: OK
  - recvkeys: OK
  - revokekey: 2 errors out of 2 [3]
  - expiration: hangs [4]
  - signing: OK
  
Python 3.6, GnuPG 1.4.22, this pull request (ea96545369d63bdc6a9799cbcb7015edd45be4eb):

  - parsers: 1 fail out of 6 [5] (related to issue #102, I think)
  - encodings: OK
  - basic: OK
  - genkey: 1 error out of 11 [6]
  - sign: 2 fails, 1 error out of 11 (similar to [1], plus [7])
  - crypt: 7 fails, 1 error out of 18 (similar to [2])
  - listkeys: OK
  - keyrings: OK
  - recvkeys: OK
  - revokekey: 2 errors out of 2 (similar to [3])
  - expiration: 3 errors out of 4 [8]
  - signing: 4 errors out of 4 [9]

Debian Jessie, Python 2.7, master (705d7f45847570102919ad50740bce0c372d1e71):

  - parsers: 1 fail out of 6 (similar to [5])
  - encodings: OK
  - basic: OK
  - genkey: 7 hangs out of 10
  - sign: 7 hangs out of 11
  - crypt: 7 hangs, 7 fail out of 18 ([10], pretty close to [2])
  - listkeys: 1 hangs out of 1
  - keyrings: 1 hangs out of 7
  - recvkeys: 1 hangs out of 1
  - revokekey: 2 errors out of 2 (similar to [3])
  - expiration: 4 hangs out of 4
  - signing: 4 hangs out of 4

Debian Jessie, Python 2.7, this pull request (ea96545369d63bdc6a9799cbcb7015edd45be4eb), excluding the tests that hanged above:

  - parsers: OK
  - encodings: OK
  - basic: OK
  - genkey: OK (excludes 7 tests)
  - sign: OK (excludes 7 tests)
  - crypt: 7 fail out of 11 (excludes 7 tests, similar to [10])
  - listkeys: OK (all tests excluded)
  - keyrings: OK (1 test excluded)
  - recvkeys: OK (all tests excluded)
  - revokekey: 2 errors out of 2 (similar to [3])
  - expiration: OK (all tests excluded)
  - signing: OK (all tests excluded)

[pr1_log.txt](https://github.com/isislovecruft/python-gnupg/files/1308940/pr1_log.txt)
