### PR TITLE
Small doc update for `decrypt()` usage

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -931,7 +931,7 @@ class GPGBase(object):
         >>> encrypted = str(gpg.encrypt(message, key.fingerprint))
         >>> assert encrypted != message
         >>> assert not encrypted.isspace()
-        >>> decrypted = str(gpg.decrypt(encrypted))
+        >>> decrypted = str(gpg.decrypt(encrypted, passphrase='foo'))
         >>> assert not decrypted.isspace()
         >>> decrypted
         'The crow flies at midnight.'

--- a/gnupg/gnupg.py
+++ b/gnupg/gnupg.py
@@ -1029,7 +1029,7 @@ generate keys. Please see
         >>> encrypted = str(gpg.encrypt(message, key.fingerprint))
         >>> assert encrypted != message
         >>> assert not encrypted.isspace()
-        >>> decrypted = str(gpg.decrypt(encrypted))
+        >>> decrypted = str(gpg.decrypt(encrypted, passphrase='foo'))
         >>> assert not decrypted.isspace()
         >>> decrypted
         'The crow flies at midnight.'


### PR DESCRIPTION
In following the docs, there was a little piece missing.