### PR TITLE
Fix for KEY_CONSIDERED issue

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -1341,13 +1341,14 @@ class ExportResult(object):
 
         :raises ValueError: if the status message is unknown.
         """
+        informational_keys = ["KEY_CONSIDERED"]
         if key in ("EXPORTED"):
             self.fingerprints.append(value)
         elif key == "EXPORT_RES":
             export_res = value.split()
             for x in self.counts.keys():
                 self.counts[x] += int(export_res.pop(0))
-        else:
+        elif key not in informational_keys:
             raise ValueError("Unknown status message: %r" % key)
 
     def summary(self):


### PR DESCRIPTION
Resolves #211

Simply creates a list of information messages requiring no other action (such as `KEY_CONSIDERED`), and doesn't let those get raised as exceptions