### PR TITLE
[bug] value of mode should be inclusive OR of flags

### DIFF
--- a/pretty_bad_protocol/_util.py
+++ b/pretty_bad_protocol/_util.py
@@ -440,7 +440,7 @@ def _has_readwrite(path):
     :rtype: bool
     :returns: True if real uid/gid has read+write permissions, False otherwise.
     """
-    return os.access(path, os.R_OK ^ os.W_OK)
+    return os.access(path, os.R_OK | os.W_OK)
 
 def _is_file(filename):
     """Check that the size of the thing which is supposed to be a filename has


### PR DESCRIPTION
[ref of doc](https://docs.python.org/3/library/os.html#os.access):
> mode should be F_OK to test the existence of path, or it can be the inclusive OR of one or more of R_OK, W_OK, and X_OK to test permissions.