### PR TITLE
Add statuses emitted by gnupg2 > 2.1.19

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -1495,11 +1495,14 @@ class Verify(object):
                 "PLAINTEXT_LENGTH",
                 "POLICY_URL",
                 "DECRYPTION_INFO",
+                "DECRYPTION_KEY",
                 "DECRYPTION_OKAY",
                 "INV_SGNR",
                 "PROGRESS",
                 "PINENTRY_LAUNCHED",
                 "SUCCESS",
+                "ENCRYPTION_COMPLIANCE_MODE",
+                "VERIFICATION_COMPLIANCE_MODE",
             ):
             pass
         elif key == "KEY_CONSIDERED":


### PR DESCRIPTION
Add DECRYPTION_KEY, ENCRYPTION_COMPLIANCE_MODE and VERIFICATION_COMPLIANCE as known and discarded statuses.

These were added in gnupg2 :
* 2.1.19 `DECRYPTION_KEY` https://github.com/gpg/gnupg/commit/effa80e0b5fd8cf9e31a984afe391c2406edee8b
* 2.1.22 `ENCRYPTION_COMPLIANCE_MODE` https://github.com/gpg/gnupg/commit/f31dc2540acf7cd7f09fd94658e815822222bfcb
* 2.1.22 `VERIFICATION_COMPLIANCE_MODE` https://github.com/gpg/gnupg/commit/be8ca8852629786266db4d3d69b2c2fb03bd6365

This fixes at least https://github.com/isislovecruft/python-gnupg/issues/207