### PR TITLE
Accept 'PINENTRY_LAUNCHED' status key on key import

### DIFF
--- a/gnupg/_parsers.py
+++ b/gnupg/_parsers.py
@@ -1253,6 +1253,8 @@ class ImportResult(object):
         if key == "IMPORTED":
             # this duplicates info we already see in import_ok & import_problem
             pass
+        elif key == ("PINENTRY_LAUNCHED"):
+            pass
         elif key == "KEY_CONSIDERED":
             self.results.append({
                 'status': key.replace("_", " ").lower(),


### PR DESCRIPTION
When importing an armor'ed key from disk, the `PINENTRY_LAUNCHED` status is emitted by GnuPG.

Let's discard it.