### PR TITLE
Test to drop options fails on GPG version 2

### DIFF
--- a/gnupg/_meta.py
+++ b/gnupg/_meta.py
@@ -516,9 +516,8 @@ class GPGBase(object):
                            "Are you sure you specified the corrent (and full) "
                            "path to the gpg binary?"))
 
-        version_line = str(result.data).partition(':version:')[2]
-        self.binary_version = version_line.split('\n')[0]
-        log.debug("Using GnuPG version %s" % self.binary_version)
+        self.binary_version = _util._version_from_list_config(str(result.data))
+        log.debug("Using GnuPGs version %s" % self.binary_version)
 
     def _make_args(self, args, passphrase=False):
         """Make a list of command line elements for GPG.

--- a/gnupg/_util.py
+++ b/gnupg/_util.py
@@ -599,6 +599,10 @@ def _make_random_string(length):
     chars = string.ascii_lowercase + string.ascii_uppercase + string.digits
     return ''.join(random.choice(chars) for x in range(length))
 
+def _version_from_list_config(data):
+    version_line = data.partition(':version:')[2]
+    return version_line.split('\n')[0]
+
 def _match_version_string(version):
     """Sort a binary version string into major, minor, and micro integers.
 


### PR DESCRIPTION
The test to check that invalid options are not passed to GPG fails when GPG version 2 is used.
Changes are as follows:
Update _meta class which sets GPG binary version to use a _util function to parse the value.
Update original test to be monkey patched to ensure the test uses GPG version 1.
Add a new test for GPG version 2 with the no longer valid option removed from the expected result.

https://github.com/isislovecruft/python-gnupg/commit/ae5cb33d6348de6afedb6f0dc82c0dd041635db5 is the commit which changed this behaviour.