### PR TITLE
Fix gpg>=1.4.18 bug where --edit-key continually asks for a passphrase.

### DIFF
--- a/pretty_bad_protocol/gnupg.py
+++ b/pretty_bad_protocol/gnupg.py
@@ -629,6 +629,8 @@ class GPG(GPGBase):
         p.stdin.write(expiration_input)
 
         result = self._result_map['expire'](self)
+        p.stdin.write(expiration_input)
+
         self._collect_output(p, result, stdin=p.stdin)
         return result
 


### PR DESCRIPTION
This is a really gross hack.

The problem is that, with gpg>=1.4.18, there appears to be absolutely no way to tell it to not ask for a passphrase on stdin if the first passphrase given to it was wrong.  None of the options that are supposed to stop it from doing this actually work: not `--no-tty`, not `--batch`, not `--passphrase-fd 0`, nothing.  It'll just hang there forever like a drooling idiot.  (Thanks, howler monkeys.)

So!  This gross hack will feed it the expiration timestamp as a second wrong passphrase to get it to finally give the fuck up.  (I seriously hope that no uses their key expiration as actual key passphrase, but even if so, this will also fix the bug.)