### PR TITLE
Handle status "DECRYPTION_COMPLIANCE_MODE"

### DIFF
--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -1513,6 +1513,7 @@ class Verify(object):
                 "UNEXPECTED",
                 "ENCRYPTION_COMPLIANCE_MODE",
                 "VERIFICATION_COMPLIANCE_MODE",
+                "DECRYPTION_COMPLIANCE_MODE",
             ):
             pass
         elif key == "KEY_CONSIDERED":


### PR DESCRIPTION
It is recognized but ignored, just like ENCRYPTION_COMPLIANCE_MODE.