### PR TITLE
Fix fingerprint parsing (issue #225)

### DIFF
--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -1146,8 +1146,9 @@ class ListKeys(list):
     pub = sec = key
 
     def fpr(self, args):
-        self.curkey['fingerprint'] = args[9]
-        self.fingerprints.append(args[9])
+        if 'fingerprint' not in self.curkey:
+            self.curkey['fingerprint'] = args[9]
+            self.fingerprints.append(args[9])
 
     def uid(self, args):
         uid = args[9]


### PR DESCRIPTION
When the key has sub keys their fingerprints overwrite the correct one. Resolves #225.