### PR TITLE
Remove the \r in the self.binary_version variable on Windows

### DIFF
--- a/pretty_bad_protocol/_meta.py
+++ b/pretty_bad_protocol/_meta.py
@@ -528,6 +528,7 @@ class GPGBase(object):
         if not version_line:
             raise RuntimeError("Got invalid version line from gpg: %s\n" % result.data)
         self.binary_version = version_line.split('\n')[0]
+        self.binary_version = self.binary_version.replace('\r', '')
         if not _VERSION_RE.match(self.binary_version):
             raise RuntimeError("Got invalid version line from gpg: %s\n" % self.binary_version)
         log.debug("Using GnuPG version %s" % self.binary_version)


### PR DESCRIPTION
Patch of the issue #254 related to the "\r" string in the self.binary_version variable for Windows gpg