### PR TITLE
Remove requirement that gpg is not a symlink

### DIFF
--- a/pretty_bad_protocol/_util.py
+++ b/pretty_bad_protocol/_util.py
@@ -395,8 +395,7 @@ def _deprefix(line, prefix, callback=None):
 def _find_binary(binary=None):
     """Find the absolute path to the GnuPG binary.
 
-    Also run checks that the binary is not a symlink, and check that
-    our process real uid has exec permissions.
+    Also check that our process real uid has exec permissions.
 
     :param str binary: The path to the GnuPG binary.
     :raises: :exc:`~exceptions.RuntimeError` if it appears that GnuPG is not
@@ -421,7 +420,7 @@ def _find_binary(binary=None):
         elif os.access(binary, os.X_OK):
             found = binary
     if found is None:
-        try: found = _which('gpg', abspath_only=True, disallow_symlinks=True)[0]
+        try: found = _which('gpg', abspath_only=True)[0]
         except IndexError as ie:
             log.error("Could not find binary for 'gpg'.")
             try: found = _which('gpg2')[0]


### PR DESCRIPTION
Requiring this check breaks compatibility with real-life. If I have a symlink to `gpg` in my path this will ignore that and report `GnuPG is not installed!` even though I can execute `gpg` myself and it works fine.

This also explicitly breaks compatibility with OSX `homebrew`, which uses symlinks to manage versioned packages:
```
$ which gpg
/usr/local/bin/gpg
$ ls -l /usr/local/bin/gpg
lrwxr-xr-x 1 user admin 30 Apr 13 21:37 /usr/local/bin/gpg -> ../Cellar/gnupg/2.2.15/bin/gpg
$ gpg --version | head -1
gpg (GnuPG) 2.2.15
$ python test.py
...
RuntimeError: GnuPG is not installed!
```

Ref #123 #69 