### PR TITLE
GPGBase: Do not set a default pubring/secring

### DIFF
--- a/pretty_bad_protocol/_meta.py
+++ b/pretty_bad_protocol/_meta.py
@@ -189,10 +189,19 @@ class GPGBase(object):
         self.ignore_homedir_permissions = ignore_homedir_permissions
         self.binary  = _util._find_binary(binary)
         self.homedir = os.path.expanduser(home) if home else _util._conf
-        pub = _parsers._fix_unsafe(keyring) if keyring else 'pubring.gpg'
-        sec = _parsers._fix_unsafe(secring) if secring else 'secring.gpg'
-        self.keyring = os.path.join(self._homedir, pub)
-        self.secring = os.path.join(self._homedir, sec)
+
+        if keyring:
+            pub = _parsers._fix_unsafe(keyring)
+            self.keyring = os.path.join(self._homedir, pub)
+        else:
+            self.keyring = None
+
+        if secring:
+            sec = _parsers._fix_unsafe(secring)
+            self.secring = os.path.join(self._homedir, sec)
+        else:
+            self.secring = None
+
         self.options = list(_parsers._sanitise_list(options)) if options else None
 
         #: The version string of our GnuPG binary


### PR DESCRIPTION
GnuPG will infer those from `homedir`, and newer versions of GnuPG (2.1.x and later, IIRC) do not store secret keys in `secring.gpg` but under `private-keys-v1.d/`.

This caused decryption failures for me, as the `gpg` subprocess couldn't find any private keys.