### PR TITLE
sometimes when exporting keys, gnupg sends back messages that aren't recognized

### DIFF
--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -1302,6 +1302,9 @@ class ImportResult(object):
             res = {'fingerprint': None,
                    'status': 'Signature expired'}
             self.results.append(res)
+
+        elif key in  ('USERID_HINT', 'NEED_PASSPHRASE', 'INQUIRE_MAXLEN',):
+            log.warnings("%s -> %s", key, value)
         else:
             raise ValueError("Unknown status message: %r" % key)
 
@@ -1564,7 +1567,7 @@ class Verify(object):
             # case of WARNING or ERROR) additional text.
             # Have fun figuring out what it means.
             self.status = value
-            log.warn("%s status emitted from gpg process: %s" % (key, value))
+            log.warning("%s status emitted from gpg process: %s" % (key, value))
         elif key == "NO_PUBKEY":
             self.valid = False
             self.key_id = value

--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -1304,7 +1304,7 @@ class ImportResult(object):
             self.results.append(res)
 
         elif key in  ('USERID_HINT', 'NEED_PASSPHRASE', 'INQUIRE_MAXLEN',):
-            log.warnings("%s -> %s", key, value)
+            log.warning("%s -> %s", key, value)
         else:
             raise ValueError("Unknown status message: %r" % key)
 

--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -1573,7 +1573,7 @@ class Verify(object):
         # pub/subkeys on the key, not just the one doing the signing.
         # if we want to check for signatures make with expired key,
         # the relevant flags are REVKEYSIG and KEYREVOKED.
-        elif key in ("KEYEXPIRED", "SIGEXPIRED"):
+        elif key in ("KEYEXPIRED", "SIGEXPIRED", "INQUIRE_MAXLEN", "DECRYPTION_COMPLIANCE_MODE"):
             pass
         # The signature has an expiration date which has already passed
         # (EXPKEYSIG), or the signature has been revoked (REVKEYSIG):

--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -991,6 +991,8 @@ class GenKey(object):
               key.startswith("PKA_TRUST_") or
               key == "NEWSIG"):
             pass
+        elif key == 'ERROR':
+           log.error("Received error %s", value)
         else:
             raise ValueError("Unknown status message: %r" % key)
 
@@ -1351,7 +1353,7 @@ class ExportResult(object):
 
         :raises ValueError: if the status message is unknown.
         """
-        informational_keys = ["KEY_CONSIDERED"]
+        informational_keys = ["KEY_CONSIDERED", 'PINENTRY_LAUNCHED']
         if key in ("EXPORTED"):
             self.fingerprints.append(value)
         elif key == "EXPORT_RES":

--- a/pretty_bad_protocol/gnupg.py
+++ b/pretty_bad_protocol/gnupg.py
@@ -320,7 +320,7 @@ class GPG(GPGBase):
                     sig_fh.close()
         return result
 
-    def import_keys(self, key_data):
+    def import_keys(self, key_data, passphrase=False):
         """
         Import the key_data into our keyring.
 
@@ -359,10 +359,11 @@ class GPG(GPGBase):
         ## xxx need way to validate that key_data is actually a valid GPG key
         ##     it might be possible to use --list-packets and parse the output
 
+        # passphrase fix from https://github.com/isislovecruft/python-gnupg/issues/205
         result = self._result_map['import'](self)
         log.info('Importing: %r', key_data[:256])
         data = _make_binary_stream(key_data, self._encoding)
-        self._handle_io(['--import'], data, result, binary=True)
+        self._handle_io(['--import'], data, result, passphrase=passphrase, binary=True)
         data.close()
         return result
 

--- a/pretty_bad_protocol/gnupg.py
+++ b/pretty_bad_protocol/gnupg.py
@@ -126,7 +126,7 @@ class GPG(GPGBase):
             ignore_homedir_permissions=ignore_homedir_permissions,
         )
 
-        log.info(textwrap.dedent("""
+        log.debug(textwrap.dedent("""
         Initialised settings:
         binary: %s
         binary version: %s

--- a/pretty_bad_protocol/test/test_gnupg.py
+++ b/pretty_bad_protocol/test/test_gnupg.py
@@ -1635,6 +1635,29 @@ know, maybe you shouldn't be doing it in the first place.
         self.assertEqual('bad passphrase: %s' % default_key_pair.fingerprint[-16:], result.status)
         self.assertNotIn(default_key_pair.fingerprint[-16:], hehe_sigs_keyids)
 
+    def test_key_export(self):
+
+        input_data = self.gpg.gen_key_input(
+            key_type='RSA',
+            expire_date=0,
+            passphrase="testme"
+        )
+
+        key = self.gpg.gen_key(input_data)
+
+
+        key_file = os.path.join("/tmp","testkey.asc")
+        pubkey = self.gpg.export_keys(key.fingerprint)
+        privkey = self.gpg.export_keys(key.fingerprint, secret=True)
+
+        with open(key_file,"w") as key_fp:
+            key_fp.write(pubkey)
+            key_fp.write(privkey)
+
+        assert os.stat(key_file).st_size > 0
+
+
+
 suites = { 'parsers': set(['test_parsers_fix_unsafe',
                            'test_parsers_fix_unsafe_semicolon',
                            'test_parsers_is_hex_valid',
@@ -1715,6 +1738,10 @@ suites = { 'parsers': set(['test_parsers_fix_unsafe',
                            'test_key_signing_with_different_key',
                            'test_signing_an_already_signed_key_does_nothing_and_is_okay',
                            'test_signing_key_with_wrong_password']),
+
+        'key_export'              : set(['test_key_export',
+        ]),
+           
 }
 
 


### PR DESCRIPTION
Ran into this while creating a text key store. Added a simple fix and test case.