### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/Complete-Guide-to-Publishing-OpenPGP-in-DNS.md
+++ b/docs/Complete-Guide-to-Publishing-OpenPGP-in-DNS.md
@@ -82,7 +82,7 @@ which I hope to outline below, both in general and for each method.
   re-publish it, especially if you gain new signatures.
 
 * Using some of these methods, you're going to be putting some pretty large,
-  pretty unwiedly lines in your DNS zones.  Not everyone will easily be able
+  pretty unwieldy lines in your DNS zones.  Not everyone will easily be able
   to retrieve them, but again, you can still publish other ways.
 
 * Using some of these methods, DNS is just a means to an end: you still need
@@ -514,7 +514,7 @@ Relevant RFCs: [RFC 2538](http://www.faqs.org/rfcs/rfc2538.html),
 [RFC 4398](http://www.faqs.org/rfcs/rfc4398.html), specifically sections 2.1
 and 3.3
 
-IPGP certs are interesting.  It's basically the same pieces of infomation that
+IPGP certs are interesting.  It's basically the same pieces of information that
 are in the PKA record, as above, except that it's supported by an RFC.
 Despite the RFC compliance, I am not sure if any non-gpg client knows to look
 for them.  However, because it's a DNS cert, make-dns-cert encodes the

--- a/examples/make-8192-bit-key.py
+++ b/examples/make-8192-bit-key.py
@@ -38,7 +38,7 @@ NEWKEY_DIR = './8192-bit-key'
 # Hammond":
 NAME = 'Someone'
 
-# The comment which goes in parantheses after the name and before the email
+# The comment which goes in parentheses after the name and before the email
 # address on the key's primary uid. Leave as None to not have one.
 NAME_COMMENT = None
 

--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -476,7 +476,7 @@ def _sanitise_list(arg_list):
 def _get_options_group(group=None):
     """Get a specific group of options which are allowed."""
 
-    #: These expect a hexidecimal keyid as their argument, and can be parsed
+    #: These expect a hexadecimal keyid as their argument, and can be parsed
     #: with :func:`_is_hex`.
     hex_options = frozenset(['--check-sigs',
                              '--default-key',

--- a/pretty_bad_protocol/gnupg.py
+++ b/pretty_bad_protocol/gnupg.py
@@ -789,7 +789,7 @@ class GPG(GPGBase):
         :param int key_length: The requested length of the generated key in
             bits. (Default: 4096)
 
-        :param str key_grip: hexstring This is an optional hexidecimal string
+        :param str key_grip: hexstring This is an optional hexadecimal string
             which is used to generate a CSR or certificate for an already
             existing key. ``key_length`` will be ignored if this parameter
             is given.

--- a/pretty_bad_protocol/test/test_gnupg.py
+++ b/pretty_bad_protocol/test/test_gnupg.py
@@ -280,17 +280,17 @@ class GPGTestCase(unittest.TestCase):
         fixed = _parsers._fix_unsafe(shell_input)
 
     def test_parsers_is_hex_valid(self):
-        """Test that valid hexidecimal passes the parsers._is_hex() check"""
+        """Test that valid hexadecimal passes the parsers._is_hex() check"""
         valid_hex = '0A6A58A14B5946ABDE18E207A3ADB67A2CDB8B35'
         self.assertTrue(_parsers._is_hex(valid_hex))
 
     def test_parsers_is_hex_lowercase(self):
-        """Test parsers._is_hex() with lowercased hexidecimal"""
+        """Test parsers._is_hex() with lowercased hexadecimal"""
         valid_hex = 'deadbeef15abad1dea'
         self.assertTrue(_parsers._is_hex(valid_hex))
 
     def test_parsers_is_hex_invalid(self):
-        """Test that invalid hexidecimal fails the parsers._is_hex() check"""
+        """Test that invalid hexadecimal fails the parsers._is_hex() check"""
         invalid_hex = 'cipherpunks write code'
         self.assertFalse(_parsers._is_hex(invalid_hex))
 


### PR DESCRIPTION
There are small typos in:
- docs/Complete-Guide-to-Publishing-OpenPGP-in-DNS.md
- examples/make-8192-bit-key.py
- pretty_bad_protocol/_parsers.py
- pretty_bad_protocol/gnupg.py
- pretty_bad_protocol/test/test_gnupg.py

Fixes:
- Should read `hexadecimal` rather than `hexidecimal`.
- Should read `unwieldy` rather than `unwiedly`.
- Should read `parentheses` rather than `parantheses`.
- Should read `information` rather than `infomation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md