### PR TITLE
logging: Update deprecated `log.warn` to `log.warning`

### DIFF
--- a/pretty_bad_protocol/_meta.py
+++ b/pretty_bad_protocol/_meta.py
@@ -128,7 +128,7 @@ class GPGMeta(type):
             except psutil.Error as err:
                 # Exception when getting proc info, possibly because the
                 # process is zombie / process no longer exist. Just ignore it.
-                log.warn("Error while attempting to find gpg-agent process: %s" % err)
+                log.warning("Error while attempting to find gpg-agent process: %s" % err)
             # Next code must be inside for operator.
             # Otherwise to _agent_proc will be saved not "gpg-agent" process buth an other.
             if ownership_match:
@@ -678,7 +678,7 @@ class GPGBase(object):
                 if not ignore:
                     # Log gpg's userland messages at our own levels:
                     if keyword.upper().startswith("WARNING"):
-                        log.warn("%s" % value)
+                        log.warning("%s" % value)
                     elif keyword.upper().startswith("FATAL"):
                         log.critical("%s" % value)
                         # Handle the gpg2 error where a missing trustdb.gpg is,
@@ -841,8 +841,8 @@ class GPGBase(object):
         if clearsign:
             args.append("--clearsign")
             if detach:
-                log.warn("Cannot use both --clearsign and --detach-sign.")
-                log.warn("Using default GPG behaviour: --clearsign only.")
+                log.warning("Cannot use both --clearsign and --detach-sign.")
+                log.warning("Using default GPG behaviour: --clearsign only.")
         elif detach and not clearsign:
             args.append("--detach-sign")
 

--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -64,7 +64,7 @@ def _check_keyserver(location):
         if location.startswith(proto):
             url = location.replace(proto, str())
             host, slash, extra = url.partition('/')
-            if extra: log.warn("URI text for %s: '%s'" % (host, extra))
+            if extra: log.warning("URI text for %s: '%s'" % (host, extra))
             log.debug("Got host string for keyserver setting: '%s'" % host)
 
             host = _fix_unsafe(host)
@@ -214,7 +214,7 @@ def _is_allowed(input):
                 assert hyphenated in allowed
             except AssertionError as ae:
                 dropped = _fix_unsafe(hyphenated)
-                log.warn("_is_allowed(): Dropping option '%s'..." % dropped)
+                log.warning("_is_allowed(): Dropping option '%s'..." % dropped)
                 raise ProtectedOption("Option '%s' not supported." % dropped)
             else:
                 return input
@@ -306,7 +306,7 @@ def _sanitise(*args):
             flag = _is_allowed(arg)
             assert flag is not None, "_check_option(): got None for flag"
         except (AssertionError, ProtectedOption) as error:
-            log.warn("_check_option(): %s" % str(error))
+            log.warning("_check_option(): %s" % str(error))
         else:
             checked += (flag + ' ')
 
@@ -414,7 +414,7 @@ def _sanitise(*args):
                         log.debug("Got value: %s" % filo[0])
                         groups[last] += filo.pop()
             else:
-                log.warn("_make_groups(): Got solitary value: %s" % last)
+                log.warning("_make_groups(): Got solitary value: %s" % last)
                 groups["xxx"] = last
         return groups
 
@@ -428,7 +428,7 @@ def _sanitise(*args):
                 log.debug("Appending option: %s" % safe)
                 checked_groups.append(safe)
             else:
-                log.warn("Dropped option: '%s %s'" % (a,v))
+                log.warning("Dropped option: '%s %s'" % (a,v))
         return checked_groups
 
     if args is not None:
@@ -449,7 +449,7 @@ def _sanitise(*args):
                 arg.reverse()
                 option_groups.update(_make_groups(arg))
             else:
-                log.warn("Got non-str/list arg: '%s', type '%s'"
+                log.warning("Got non-str/list arg: '%s', type '%s'"
                          % (arg, type(arg)))
         checked = _check_groups(option_groups)
         sanitised = ' '.join(x for x in checked)
@@ -979,7 +979,7 @@ class GenKey(object):
         elif key == "PROGRESS":
             self.status = progress(value.split(' ', 1)[0])
         elif key == "PINENTRY_LAUNCHED":
-            log.warn(("GnuPG has just attempted to launch whichever pinentry "
+            log.warning(("GnuPG has just attempted to launch whichever pinentry "
                       "program you have configured, in order to obtain the "
                       "passphrase for this key.  If you did not use the "
                       "`passphrase=` parameter, please try doing so.  Otherwise, "
@@ -1254,7 +1254,7 @@ class ImportResult(object):
             # this duplicates info we already see in import_ok & import_problem
             pass
         elif key == "PINENTRY_LAUNCHED":
-            log.warn(("GnuPG has just attempted to launch whichever pinentry "
+            log.warning(("GnuPG has just attempted to launch whichever pinentry "
                       "program you have configured, in order to obtain the "
                       "passphrase for this key.  If you did not use the "
                       "`passphrase=` parameter, please try doing so.  Otherwise, "
@@ -1562,7 +1562,7 @@ class Verify(object):
             # case of WARNING or ERROR) additional text.
             # Have fun figuring out what it means.
             self.status = value
-            log.warn("%s status emitted from gpg process: %s" % (key, value))
+            log.warning("%s status emitted from gpg process: %s" % (key, value))
         elif key == "NO_PUBKEY":
             self.valid = False
             self.key_id = value

--- a/pretty_bad_protocol/_util.py
+++ b/pretty_bad_protocol/_util.py
@@ -590,7 +590,7 @@ def _make_passphrase(length=None, save=False, file=None):
             os.chmod(file, stat.S_IRUSR | stat.S_IWUSR)
             os.chown(file, ruid, gid)
 
-        log.warn("Generated passphrase saved to %s" % file)
+        log.warning("Generated passphrase saved to %s" % file)
     return passphrase
 
 def _make_random_string(length):
@@ -702,10 +702,10 @@ def _which(executable, flags=os.X_OK, abspath_only=False, disallow_symlinks=Fals
         if not os.access(p, flags):
             return False
         if abspath_only and not os.path.abspath(p):
-            log.warn('Ignoring %r (path is not absolute)', p)
+            log.warning('Ignoring %r (path is not absolute)', p)
             return False
         if disallow_symlinks and os.path.islink(p):
-            log.warn('Ignoring %r (path is a symlink)', p)
+            log.warning('Ignoring %r (path is a symlink)', p)
             return False
         return True
 

--- a/pretty_bad_protocol/gnupg.py
+++ b/pretty_bad_protocol/gnupg.py
@@ -248,7 +248,7 @@ class GPG(GPGBase):
             log.info("Signing message '%r' with keyid: %s"
                      % (data, kwargs['default_key']))
         else:
-            log.warn("No 'default_key' given! Using first key on secring.")
+            log.warning("No 'default_key' given! Using first key on secring.")
 
         if hasattr(data, 'read'):
             result = self._sign_file(data, **kwargs)
@@ -257,7 +257,7 @@ class GPG(GPGBase):
             result = self._sign_file(stream, **kwargs)
             stream.close()
         else:
-            log.warn("Unable to sign message '%s' with type %s"
+            log.warning("Unable to sign message '%s' with type %s"
                      % (data, type(data)))
             result = None
         return result

--- a/pretty_bad_protocol/test/test_gnupg.py
+++ b/pretty_bad_protocol/test/test_gnupg.py
@@ -259,7 +259,7 @@ class GPGTestCase(unittest.TestCase):
             except OSError as ose:
                 log.error(ose)
         else:
-            log.warn("Can't delete homedir: '%s' not a directory"
+            log.warning("Can't delete homedir: '%s' not a directory"
                      % self.homedir)
 
     def test_parsers_fix_unsafe(self):
@@ -835,8 +835,8 @@ class GPGTestCase(unittest.TestCase):
         verified = self.gpg.verify(sig.data)
         self.assertIsNotNone(verified.fingerprint)
         if key.fingerprint != verified.fingerprint:
-            log.warn("key fingerprint:      %r", key.fingerprint)
-            log.warn("verified fingerprint: %r", verified.fingerprint)
+            log.warning("key fingerprint:      %r", key.fingerprint)
+            log.warning("verified fingerprint: %r", verified.fingerprint)
         self.assertEqual(key.fingerprint, verified.fingerprint,
                          "Fingerprints must match")
         self.assertEqual(verified.status, 'signature valid')
@@ -863,8 +863,8 @@ class GPGTestCase(unittest.TestCase):
         except UnicodeDecodeError: #happens in Python 2.6
             verified = self.gpg.verify_file(io.BytesIO(sig.data))
         if key.fingerprint != verified.fingerprint:
-            log.warn("key fingerprint:      %r", key.fingerprint)
-            log.warn("verified fingerprint: %r", verified.fingerprint)
+            log.warning("key fingerprint:      %r", key.fingerprint)
+            log.warning("verified fingerprint: %r", verified.fingerprint)
         self.assertEqual(key.fingerprint, verified.fingerprint)
 
     def test_signature_verification_detached(self):
@@ -892,8 +892,8 @@ class GPGTestCase(unittest.TestCase):
         verified = self.gpg.verify_file(datafd, sig_file=sigfn)
 
         if key.fingerprint != verified.fingerprint:
-            log.warn("key fingerprint:      %r", key.fingerprint)
-            log.warn("verified fingerprint: %r", verified.fingerprint)
+            log.warning("key fingerprint:      %r", key.fingerprint)
+            log.warning("verified fingerprint: %r", verified.fingerprint)
         self.assertEqual(key.fingerprint, verified.fingerprint)
 
         if os.path.isfile(sigfn):
@@ -1775,7 +1775,7 @@ def before_run():
                     os.rename(ring, os.path.join(genkeysdir, fn))
                 except OSError as err:
                     ## if we can't move the files it won't kill us:
-                    log.warn(err)
+                    log.warning(err)
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
## Summary
Updates deprecated `log.warn` to `log.warning`

## Warning Encountered

```
test/hooks/gpg_private_key_hook/gpg_private_key_hook_test.py::GpgPrivateKeyHookTest::test_import_encrypt_decrypt_file
test/hooks/gpg_private_key_hook/gpg_private_key_hook_test.py::GpgPrivateKeyHookTest::test_import_encrypt_decrypt_stream
  /home/airflow/.local/lib/python3.8/site-packages/pretty_bad_protocol/_meta.py:681: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn("%s" % value)
```