### PR TITLE
Allow passing --ignore-mdc-error option

### DIFF
--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -571,6 +571,7 @@ def _get_options_group(group=None):
                               '--fingerprint',
                               '--fixed-list-mode',
                               '--gen-key',
+                              '--ignore-mdc-error',
                               '--import-ownertrust',
                               '--list-config',
                               '--list-key',


### PR DESCRIPTION
With gpg2+ mdc errors force the decryption process to return a non-zero status code, with a warning even if the decryption was successful.

Currently the `--ignore-mdc-error` option is not in the allowed list of options and is removed by the parser.

While it is a security risk to ignore mdc errors while decrypting messages, it is a useful option to have for message signed by older systems.

Note: This option maybe removed from the gpg standard at some point in the future.