### PR TITLE
Fix typo

### DIFF
--- a/pretty_bad_protocol/_parsers.py
+++ b/pretty_bad_protocol/_parsers.py
@@ -100,7 +100,7 @@ def _check_preferences(prefs, pref_type=None):
     elif isinstance(prefs, list):
         prefs = set(prefs)
     else:
-        msg = "prefs must be list of strings, or space-separated string"
+        message = "prefs must be list of strings, or space-separated string"
         log.error("parsers._check_preferences(): %s" % message)
         raise TypeError(message)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<redacted>", line 73, in setUpClass
    cls.gpg = gnupg.GPG(homedir=cls.gpg_home, options=gpg_options)
  File "/virtualenv/lib/python2.7/site-packages/gnupg/gnupg.py", line 125, in __init__
    ignore_homedir_permissions=ignore_homedir_permissions,
  File "/virtualenv/lib/python2.7/site-packages/gnupg/_meta.py", line 188, in __init__
    self.options = list(_parsers._sanitise_list(options)) if options else None
  File "/virtualenv/lib/python2.7/site-packages/gnupg/_parsers.py", line 472, in _sanitise_list
    safe_arg = _sanitise(arg)
  File "/virtualenv/lib/python2.7/site-packages/gnupg/_parsers.py", line 454, in _sanitise
    checked = _check_groups(option_groups)
  File "/virtualenv/lib/python2.7/site-packages/gnupg/_parsers.py", line 426, in _check_groups
    safe = _check_option(a, v)
  File "/virtualenv/lib/python2.7/site-packages/gnupg/_parsers.py", line 377, in _check_option
    legit_modes = _check_preferences(val, 'pinentry')
  File "/virtualenv/lib/python2.7/site-packages/gnupg/_parsers.py", line 104, in _check_preferences
    log.error("parsers._check_preferences(): %s" % message)
NameError: global name 'message' is not defined
```
